### PR TITLE
fix: pin scipy to <1.16 for Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 openai>=1.0.0
 numpy==1.24.3
 scikit-learn==1.2.1
-scipy>=1.17.1
+scipy>=1.10.0,<1.16
 Pillow>=12.2.0
 requests>=2.34.2
 httpx>=0.24.0


### PR DESCRIPTION
scipy>=1.17.1 requires Python>=3.11。CI 使用 Python 3.10，因此需要限制 scipy 版本。