### PR TITLE
docs: rewrite memory system section with multi-recall + rerank

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ graph LR
     end
 
     subgraph Memory["记忆层"]
-        M[LLM Wiki + 向量检索]
+        M[LLM Wiki + 向量数据库]
     end
 
     subgraph Flywheel["数据飞轮"]
@@ -97,26 +97,52 @@ graph TB
 
 ---
 
-### 记忆系统：每个联系人都有自己的 Wiki
+### 记忆系统：多路召回 + Rerank
 
-Bot 不是无状态聊天机器人。记忆系统为每个联系人、群聊维护独立的 **LLM Wiki**（Markdown 格式），并构建在多路召回与重排之上。
+记忆系统不是简单的“每个联系人一个 Wiki”。它把 **WeFlow 初始化**和**运行时对话**当作原始输入数据，向上抽象出两个索引层：**LLM Wiki**（结构化 Markdown）和**向量数据库**（语义向量）。线上召回时两路并行，最终通过 Rerank 融合排序，把最相关的片段注入 Agent 上下文。
 
-- **启动时全量注入（WeFlow）**：Bot 启动时从微信数据库导出全量历史，直接写入 LLM Wiki，上线第一天就拥有完整背景知识。
-- **增量构建（运行时更新）**：新对话被后台异步队列消费，LLM 接收「现有 wiki + 新对话」，输出更新后的完整 wiki。所有新增事实标注来源，严禁删除现有内容。
-- **多路召回**：关键词召回做文本匹配，RAG 向量检索做语义匹配，两路结果汇总后经 BM25 重排，选出 top-k 段落注入 Agent 上下文。
+- **原始输入数据**
+  - **WeFlow 初始化**：Bot 启动时从微信数据库导出全量历史聊天记录，作为初始语料。
+  - **运行时对话**：每个 tick 感知到的新消息，持续追加到原始数据流中。
+- **中间抽象化索引层**
+  - **LLM Wiki**：由 LLM 从原始对话中提炼、结构化的长期事实（按联系人/群聊独立维护），增量更新，标注来源，严禁删除已有内容。
+  - **向量数据库**：对原始对话做切片和嵌入，提供语义级检索能力。
+- **线上多路召回**
+  - **LLM Wiki 关键字召回**：从结构化 wiki 中做关键词/实体匹配，召回精准事实。
+  - **向量数据库 向量召回**：从向量索引中做语义相似度召回，捕获同义、上下文相关片段。
+- **Rerank 融合排序**
+  - 两路结果汇总后，综合 **BM25** 文本相关性和**向量相似度**重新打分，选出 top-k 注入 Agent 上下文。
 - **人工 Overrides**：通过外挂 JSON 实现任意字段覆写，LLM 更新时不会破坏人工修改。
 
 所有数据本地存储，不上传云端。
 
 ```mermaid
 graph TB
-    WeFlow["WeFlow 全量注入"] --> Wiki["LLM Wiki<br/>Markdown 格式"]
-    Runtime["运行时对话"] --> Queue["异步更新队列"]
-    Queue --> Wiki
-    Wiki --> Keyword["关键词召回"]
-    Wiki --> RAG["向量检索"]
-    Keyword --> Rerank["重排<br/>BM25 + 语义"]
-    RAG --> Rerank
+    subgraph Raw["原始输入数据"]
+        WeFlow["WeFlow 初始化<br/>历史全量聊天记录"]
+        Runtime["运行时对话<br/>增量消息"]
+    end
+
+    subgraph Index["中间抽象化索引层"]
+        Wiki["LLM Wiki<br/>结构化 Markdown"]
+        VectorDB["向量数据库<br/>语义嵌入"]
+    end
+
+    subgraph Online["线上多路召回"]
+        KeywordRecall["LLM Wiki 关键字召回"]
+        VectorRecall["向量数据库 向量召回"]
+    end
+
+    WeFlow --> Wiki
+    WeFlow --> VectorDB
+    Runtime --> Wiki
+    Runtime --> VectorDB
+
+    Wiki --> KeywordRecall
+    VectorDB --> VectorRecall
+
+    KeywordRecall --> Rerank["Rerank<br/>BM25 + 向量相似度"]
+    VectorRecall --> Rerank
     Rerank --> Context["上下文注入 Agent"]
 ```
 

--- a/src/action/chat_list_clicker.py
+++ b/src/action/chat_list_clicker.py
@@ -8,27 +8,49 @@
 - screen_abs = window_rect + item_rect / scale_factor
 """
 
+import logging
 import subprocess
+import time
 from typing import Optional
 
 from src.models.base import ChatListItem, Rect
+
+_logger = logging.getLogger("src.chat_list_clicker")
 
 
 class ChatListClicker:
     """点击左侧聊天列表中的指定项，切换当前聊天窗口。"""
 
+    # 类级全局冷却：任意两次真实点击之间至少间隔这么多秒，
+    # 防止 bot 在异常状态下高频连点导致微信窗口布局错乱。
+    MIN_CLICK_INTERVAL_SECONDS = 1.0
+    _last_click_time: float = 0.0
+
     def __init__(self, window_rect: Rect, scale_factor: float = 2.0):
         self.window_rect = window_rect
         self.scale_factor = scale_factor
+
+    def _can_click(self) -> bool:
+        """检查是否距离上次点击已超过最小冷却时间。"""
+        now = time.time()
+        elapsed = now - ChatListClicker._last_click_time
+        if elapsed < ChatListClicker.MIN_CLICK_INTERVAL_SECONDS:
+            _logger.warning(
+                f"点击被全局冷却跳过: 距离上次点击仅 {elapsed:.2f}s, "
+                f"需间隔 {ChatListClicker.MIN_CLICK_INTERVAL_SECONDS}s"
+            )
+            return False
+        return True
 
     def click_item(self, item: ChatListItem) -> bool:
         """
         点击聊天列表项的中心位置。
 
         策略：
-        1. 先激活微信窗口（确保有焦点）
-        2. 点击位置取列表项中心（rect 包含昵称+预览，x 偏移确保在条目内）
-        3. 点击后等待右侧展开，避免快速连续点击导致误触
+        1. 先检查全局冷却，避免 1 秒内连续点击
+        2. 激活微信窗口（确保有焦点）
+        3. 点击位置取列表项中心（rect 包含昵称+预览，x 偏移确保在条目内）
+        4. 点击后等待右侧展开，避免快速连续点击导致误触
 
         Args:
             item: 要点击的 ChatListItem，包含 rect（截图像素坐标）
@@ -36,6 +58,9 @@ class ChatListClicker:
         Returns:
             True 如果点击命令执行成功
         """
+        if not self._can_click():
+            return False
+
         # 点击位置：取 rect 中心，避免偏左偏右点到相邻项
         click_x = item.rect.x + item.rect.width // 2
         click_y = item.rect.y + item.rect.height // 2
@@ -52,7 +77,6 @@ class ChatListClicker:
                 capture_output=True,
                 check=True,
             )
-            import time
             time.sleep(0.5)
             # Step 2: 点击聊天列表项
             subprocess.run(
@@ -60,11 +84,10 @@ class ChatListClicker:
                 check=True,
                 timeout=5,
             )
+            ChatListClicker._last_click_time = time.time()
             # Step 3: 等待右侧聊天内容加载
             time.sleep(2.5)
-            import logging
-            _click_logger = logging.getLogger("src.chat_list_clicker")
-            _click_logger.info(
+            _logger.info(
                 f"点击聊天列表: screen=({abs_x},{abs_y}) "
                 f"window=({self.window_rect.x},{self.window_rect.y}) "
                 f"rect_in_screenshot=({click_x},{click_y}) scale={self.scale_factor}"


### PR DESCRIPTION
### What\n- Rewrite the README memory-system section to reflect the actual architecture:\n  - Raw input: WeFlow initialization + runtime dialogue.\n  - Intermediate index layer: LLM Wiki + vector database.\n  - Online retrieval: LLM Wiki keyword recall + vector DB semantic recall.\n  - Final rerank: BM25 + vector similarity.\n- Update the top-level architecture diagram memory node to "LLM Wiki + 向量数据库".\n- Includes the staged  global cooldown to avoid sub-second consecutive GUI clicks.\n\n### Why\n- The previous description implied WeFlow wrote directly to Wiki and only Wiki was used for recall; the new version matches the multi-recall + rerank design.