### PR TITLE
ci: add quality workflow (ruff, mypy, bandit, coverage)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,90 @@
+name: Quality
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  ruff-critical:
+    name: Ruff Critical Checks
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install ruff
+      - run: ruff check src --select E9,F63,F7,F82
+
+  ruff-style:
+    name: Ruff Style / Import Checks
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install ruff
+      # 目前仓库遗留风格问题较多，先只报告不阻塞 merge； issues 输出到日志。
+      - run: ruff check src || true
+
+  mypy:
+    name: Mypy Type Check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install mypy types-requests types-beautifulsoup4 types-Pillow
+      # 目前类型注解遗留问题较多，先只报告不阻塞 merge； issues 输出到日志。
+      - run: mypy src || true
+
+  bandit:
+    name: Bandit Security Scan
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install bandit
+      - run: bandit -r src -f json -o bandit-report.json || true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bandit-report
+          path: bandit-report.json
+          if-no-files-found: ignore
+
+  coverage:
+    name: Test Coverage
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install -r requirements.txt
+      - run: |
+          pytest \
+            src/tests/test_reply.py \
+            src/tests/test_debug_logger.py \
+            src/tests/test_layout_profile.py \
+            src/tests/test_message_extractor.py \
+            src/tests/test_session_memory.py \
+            --cov=src --cov-report=xml --cov-report=term
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+warn_return_any = false
+warn_unused_configs = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,8 @@ uvicorn>=0.23.0
 pytest>=7.0.0
 pytest-asyncio>=0.21.0
 pytest-cov>=7.1.0
+
+# 代码质量 / CI
+ruff>=0.11.0
+mypy>=1.15.0
+bandit>=1.8.0

--- a/src/badcase/case_db.py
+++ b/src/badcase/case_db.py
@@ -13,12 +13,15 @@ Case Database — SQLite 存储所有 badcase 的完整信息（原始 prompt、
 """
 
 import json
+import logging
 import sqlite3
 import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 DB_PATH = PROJECT_ROOT / "data" / "cases.db"

--- a/src/capture/window_capture.py
+++ b/src/capture/window_capture.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """L2 Capture - 窗口截图模块"""
 
+import glob
 import logging
+import os
 import subprocess
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 import Quartz
@@ -204,7 +207,6 @@ class WindowCapture:
         t_capture_start = time.time()
         # 清理旧截图（超过1小时的临时文件，避免 /tmp 无限累积）
         try:
-            import glob
             cutoff = time.time() - 3600
             for old in glob.glob("/tmp/wechat_capture_*.png"):
                 try:
@@ -217,8 +219,6 @@ class WindowCapture:
 
         # 每次调用生成新的输出路径，避免覆盖旧截图
         # 这是 SmartPerceptionPipeline 像素 diff 正确工作的前提
-        import os
-        from datetime import datetime
         ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
         pid = os.getpid()
         self.output_path = f"/tmp/wechat_capture_{ts}_{pid}.png"

--- a/src/message/extractor.py
+++ b/src/message/extractor.py
@@ -2,7 +2,7 @@
 """L3 Message Extractor - 从 UILayout 中提取结构化消息"""
 
 import re
-from typing import List
+from typing import Any, Dict, List
 
 from src.models.base import ChatMessage, OCRTextElement, Point, Rect, SenderType
 from src.layout.layout_parser import UILayout, TIMESTAMP_PATTERNS

--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -110,6 +110,7 @@ def extract_context_around_keywords(
     result_parts = []
     used_chars = 0
     budget = max_chars
+    last_end = 0
 
     # 先取第一个窗口（通常最重要），完整保留
     for window in merged:


### PR DESCRIPTION
### What\n- New  with 5 jobs:\n  - : must pass (syntax errors, undefined names).\n  - : style/import checks,  for now.\n  - : static type check, .\n  - usage: bandit [-h] [-r] [-a {file,vuln}] [-n CONTEXT_LINES] [-c CONFIG_FILE]
              [-p PROFILE] [-t TESTS] [-s SKIPS]
              [-l | --severity-level {all,low,medium,high}]
              [-i | --confidence-level {all,low,medium,high}]
              [-f {csv,custom,html,json,screen,txt,xml,yaml}]
              [--msg-template MSG_TEMPLATE] [-o [OUTPUT_FILE]] [-v] [-d] [-q]
              [--ignore-nosec] [-x EXCLUDED_PATHS] [-b BASELINE]
              [--ini INI_PATH] [--exit-zero] [--version]
              [targets ...]: security scan, .\n  - Code coverage for Python, version 7.13.5 with C extension. Use 'coverage help' for help.
Full documentation is at https://coverage.readthedocs.io/en/7.13.5: pytest with , uploads report, no threshold gate.\n- Add  with ruff and mypy config.\n- Add , , usage: bandit [-h] [-r] [-a {file,vuln}] [-n CONTEXT_LINES] [-c CONFIG_FILE]
              [-p PROFILE] [-t TESTS] [-s SKIPS]
              [-l | --severity-level {all,low,medium,high}]
              [-i | --confidence-level {all,low,medium,high}]
              [-f {csv,custom,html,json,screen,txt,xml,yaml}]
              [--msg-template MSG_TEMPLATE] [-o [OUTPUT_FILE]] [-v] [-d] [-q]
              [--ignore-nosec] [-x EXCLUDED_PATHS] [-b BASELINE]
              [--ini INI_PATH] [--exit-zero] [--version]
              [targets ...] to .\n- Fix F821 undefined-name errors so  is green.\n\n### Notes\n- Style/type/security jobs are set to  so they report issues without blocking merges while the codebase is being cleaned up.\n- Critical lint errors are now blocking.