### PR TITLE
fix: clean up remaining Code Scanning notes

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """wechat-twin Bot — 合并重构版本"""
+import logging
 import sys, os, fcntl
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -19,6 +20,8 @@ from src.layout.profile import PROFILE_WECHAT_MAC_1760X1280
 from src.perception.smart_pipeline import SmartPerceptionPipeline
 from src.utils.qwen_client import QwenClient
 
+_logger = logging.getLogger(__name__)
+
 
 class SingleInstanceLock:
     def __init__(self, pid_file=""):
@@ -30,7 +33,8 @@ class SingleInstanceLock:
         old_pid = ""
         try:
             with open(self.pid_file) as f: old_pid = f.read().strip()
-        except: pass
+        except Exception as e:
+            _logger.warning("read pid file failed: %s", e)
         try:
             self.fd = open(self.pid_file, "r+")
         except FileNotFoundError:
@@ -50,7 +54,8 @@ class SingleInstanceLock:
             fcntl.flock(self.fd, fcntl.LOCK_UN)
             self.fd.close()
             try: os.remove(self.pid_file)
-            except: pass
+            except Exception as e:
+                _logger.warning("remove pid file failed: %s", e)
 
 
 def main():

--- a/scripts/acp_audit_demo.py
+++ b/scripts/acp_audit_demo.py
@@ -6,7 +6,7 @@ ACP 代码审计 Demo
 import asyncio
 import json
 import sys
-from contextlib import asynccontextmanager
+
 from pathlib import Path
 from typing import Optional
 
@@ -16,7 +16,7 @@ sys.path.insert(0, '/Users/yihanwang/.local/share/uv/tools/kimi-cli/lib/python3.
 import acp
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.staticfiles import StaticFiles
+
 import uvicorn
 
 

--- a/scripts/acp_audit_demo_v2.py
+++ b/scripts/acp_audit_demo_v2.py
@@ -4,16 +4,19 @@ ACP 代码审计 Demo v2 - 使用 kimi --print 直接调用，更稳定
 """
 import asyncio
 import json
-import subprocess
+
 import sys
+import logging
 from pathlib import Path
-from typing import Optional
+
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 import uvicorn
+
+_logger = logging.getLogger(__name__)
 
 
 WORK_DIR = "/Users/yihanwang/wechat-mac-rpa"
@@ -91,8 +94,8 @@ async def analyze_with_kimi(issue: dict, notes: str, timeout: int = 300) -> dict
     except asyncio.TimeoutError:
         try:
             proc.kill()
-        except:
-            pass
+        except Exception as e:
+            _logger.warning("proc.kill failed: %s", e)
         return {"success": False, "error": f"分析超时（>{timeout}秒）"}
     except Exception as e:
         print(f"[Analyze] Error: {e}")

--- a/scripts/batch_generate_wiki_v2.py
+++ b/scripts/batch_generate_wiki_v2.py
@@ -6,7 +6,7 @@
 """
 
 import argparse
-import json
+
 import sys
 import time
 from pathlib import Path
@@ -63,10 +63,8 @@ def main():
         sys.exit(1)
     engine = MemoryEngine(llm_client=llm)
 
-    total = 0
     success = 0
     failed = 0
-    skipped = 0
     start_all = time.time()
 
     for idx, (name, state, _) in enumerate(chats, 1):

--- a/scripts/batch_generate_wiki_v3.py
+++ b/scripts/batch_generate_wiki_v3.py
@@ -59,7 +59,6 @@ def main():
         sys.exit(1)
     engine = MemoryEngine(llm_client=llm)
 
-    total = 0
     success = 0
     failed = 0
     start_all = time.time()

--- a/scripts/batch_generate_wiki_v4.py
+++ b/scripts/batch_generate_wiki_v4.py
@@ -5,16 +5,19 @@
 - 断点续传（跳过已有 wiki 文件）
 - 保存到 data/memory/wiki/groups/
 """
-import os
+
 import sys
 import time
 from pathlib import Path
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.session.global_store import GlobalStore
 from src.utils.qwen_client import QwenClient
+
+_logger = logging.getLogger(__name__)
 
 client = QwenClient(model="deepseek-v4-flash")
 wiki_dir = Path("data/memory/wiki/groups")
@@ -89,8 +92,8 @@ def format_conversation(messages):
         if ts_int:
             try:
                 tstr = datetime.fromtimestamp(int(ts_int)).strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.warning("timestamp conversion failed: %s", e)
         lines.append(f"[{tstr}] {sender}: {text}")
     return "\n".join(lines)
 

--- a/scripts/benchmark_qwen_vl_ocr.py
+++ b/scripts/benchmark_qwen_vl_ocr.py
@@ -21,10 +21,10 @@ import os
 import random
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 # 将项目根目录加入路径
 PROJECT_ROOT = Path(__file__).parent.parent

--- a/scripts/bulk_import_fast.py
+++ b/scripts/bulk_import_fast.py
@@ -10,6 +10,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.session.global_store import GlobalStore
 from openai import OpenAI
 import chromadb
+import logging
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
@@ -30,8 +33,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 full_context = "\n".join(lines)
@@ -75,8 +78,8 @@ coll_name = re.sub(r"[^a-zA-Z0-9_-]", "_", target_name)
 chroma = chromadb.PersistentClient(path="data/wechat_bulk_optimal")
 try:
     chroma.delete_collection(coll_name)
-except:
-    pass
+except Exception as e:
+    _logger.warning("delete collection failed: %s", e)
 collection = chroma.get_or_create_collection(coll_name)
 collection.add(
     ids=[str(uuid.uuid4()) for _ in facts],

--- a/scripts/bulk_import_from_chats.py
+++ b/scripts/bulk_import_from_chats.py
@@ -27,9 +27,10 @@ import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -43,8 +44,10 @@ if env_file.exists():
                 key, value = line.split("=", 1)
                 os.environ.setdefault(key.strip(), value.strip())
 
-from src.memory.engine import MemoryEngine, _DEFAULT_USER_WIKI, _DEFAULT_GROUP_WIKI
+from src.memory.engine import MemoryEngine
 from src.utils.qwen_client import QwenClient
+
+_logger = logging.getLogger(__name__)
 
 
 CHATS_DIR = Path("data/chats")
@@ -147,7 +150,6 @@ def build_wxid_index(all_chats: dict) -> dict:
     raw = defaultdict(lambda: {"names": defaultdict(int), "chats": defaultdict(list)})
 
     for stem, data in all_chats.items():
-        chat_name = data.get("chat_name", "") or stem
         for m in data.get("messages", []):
             if m.get("sender_type") == "self":
                 continue
@@ -197,8 +199,8 @@ def load_aliases() -> dict:
                 name_to_main[main_name] = main_name
                 for alias in cfg.get("aliases", []):
                     name_to_main[alias] = main_name
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load alias config failed: %s", e)
     return existing, name_to_main
 
 
@@ -233,8 +235,8 @@ def update_aliases_json(wxid_index: dict, name_to_main: dict, dry_run: bool = Fa
         try:
             with open(aliases_path, encoding="utf-8") as f:
                 existing = json.load(f).get("users", {})
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load aliases failed: %s", e)
 
     added = 0
     for wxid, info in wxid_index.items():
@@ -724,8 +726,8 @@ def main():
                 if m.get("time"):
                     try:
                         tstr = datetime.fromtimestamp(int(m["time"])).strftime("%Y-%m-%d")
-                    except:
-                        pass
+                    except Exception as e:
+                        _logger.warning("timestamp conversion failed: %s", e)
                 lines.append(f"- [{tstr}] {m['sender']} @ {m['chat']}: {m['text'][:100]}")
 
             path = topics_dir / f"{topic}.md"

--- a/scripts/bulk_import_optimal.py
+++ b/scripts/bulk_import_optimal.py
@@ -10,6 +10,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.session.global_store import GlobalStore
 from openai import OpenAI
 import chromadb
+import logging
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
@@ -31,8 +34,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 full_context = "\n".join(lines)

--- a/scripts/bulk_import_with_mem0.py
+++ b/scripts/bulk_import_with_mem0.py
@@ -8,11 +8,14 @@
 import os, json, sys
 from pathlib import Path
 from datetime import datetime
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.session.global_store import GlobalStore
 from mem0 import Memory
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 
@@ -57,8 +60,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 full_context = "\n".join(lines)

--- a/scripts/experiment_loop.py
+++ b/scripts/experiment_loop.py
@@ -8,9 +8,9 @@
   python3 scripts/experiment_loop.py --compare 6 7                  # 对比两个实验
 """
 
-import json, os, sqlite3, sys, subprocess
+import json, sqlite3, sys, subprocess
 from pathlib import Path
-from datetime import datetime
+
 
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -148,7 +148,6 @@ def print_iteration_insights(analysis: dict):
     # 建议下一步
     print(f"\n   💡 下一步建议:")
     worst_dim = analysis['worst_dimension']
-    best_dim = analysis['best_dimension']
     if worst_dim[1] < -0.3:
         print(f"      1. 修复退化维度: {worst_dim[0]} ({worst_dim[1]:+.1f})")
     if analysis['degraded']:
@@ -178,7 +177,7 @@ def run_and_analyze(exp_name: str, all_labeled: bool = False, n_samples: int = 5
     analysis = analyze_experiment(latest_id)
     if "error" in analysis:
         print(f"Error: {analysis['error']}")
-        return
+        return None
 
     print_iteration_insights(analysis)
     print(f"\n📊 详细报告: http://localhost:8766/experiments/{latest_id}")

--- a/scripts/generate_benchmark_dashboard.py
+++ b/scripts/generate_benchmark_dashboard.py
@@ -4,6 +4,7 @@
 import json, sys, os, sqlite3
 from pathlib import Path
 from datetime import datetime
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 env_file = Path(__file__).parent.parent / ".env"
@@ -14,6 +15,8 @@ if env_file.exists():
             if line and not line.startswith("#") and "=" in line:
                 k, v = line.split("=", 1)
                 os.environ.setdefault(k.strip(), v.strip())
+
+_logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).parent.parent
 DB_PATH = PROJECT_ROOT / "data" / "cases.db"
@@ -78,7 +81,9 @@ def build_judge_html() -> str:
         d = dict(r)
         dims_json = d.get("judge_dimensions_json", "{}") or "{}"
         try: dims = json.loads(dims_json)
-        except: dims = {}
+        except Exception as e:
+            _logger.warning("load judge dimensions failed: %s", e)
+            dims = {}
         target = dim_scores_bad if d["human_is_badcase"] else dim_scores_ok
         for dim_name in DIM_NAMES:
             s = dims.get(dim_name, {}).get("score", 0)
@@ -131,7 +136,9 @@ def build_judge_html() -> str:
         # 维度 bars
         dims_json = d.get("judge_dimensions_json", "{}") or "{}"
         try: dims = json.loads(dims_json)
-        except: dims = {}
+        except Exception as e:
+            _logger.warning("load judge dimensions failed: %s", e)
+            dims = {}
         dim_bars = ""
         for i, dim_name in enumerate(DIM_NAMES):
             s = dims.get(dim_name, {}).get("score", 0)
@@ -139,7 +146,9 @@ def build_judge_html() -> str:
 
         replies = d.get("replies_sent_json", "[]") or "[]"
         try: rlist = json.loads(replies); reply = " | ".join(rlist) if isinstance(rlist, list) else replies
-        except: reply = replies
+        except Exception as e:
+            _logger.warning("load replies failed: %s", e)
+            reply = replies
 
         html += f"""<div class="card {cls} c {filter_class}">
   <h3>{icon} <a href="/ticks/{d['id']}" style="color:var(--blue)">{sid}:#{d['tick_id']}</a> <span style="font-size:10px;color:var(--muted)">{d.get('chat_name','')}</span></h3>
@@ -179,10 +188,14 @@ def load_all_reply_cases() -> list:
         d = dict(r)
         replies = d.get("replies_sent_json", "[]") or "[]"
         try: rlist = json.loads(replies); bot_reply = " | ".join(rlist) if isinstance(rlist, list) else replies
-        except: bot_reply = replies
+        except Exception as e:
+            _logger.warning("load bot replies failed: %s", e)
+            bot_reply = replies
         tc = d.get("tool_calls_json", "[]") or "[]"
         try: tool_calls = json.loads(tc)
-        except: tool_calls = []
+        except Exception as e:
+            _logger.warning("load tool calls failed: %s", e)
+            tool_calls = []
         cases.append({
             "id": d["id"], "session_id": d.get("session_id", ""), "tick_id": d.get("tick_id", 0),
             "chat_name": d.get("chat_name", ""), "bot_reply": bot_reply,

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -11,13 +11,16 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+import logging
+
 
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 HISTORY_DIR = PROJECT_ROOT / "data" / "benchmark_history"
 REPORT_PATH = PROJECT_ROOT / "benchmark_dashboard.html"
+
+_logger = logging.getLogger(__name__)
 
 
 def _load_history(days: int = 90) -> list[dict]:
@@ -29,8 +32,8 @@ def _load_history(days: int = 90) -> list[dict]:
             data = json.loads(f.read_text(encoding="utf-8"))
             data["date"] = f.stem
             records.append(data)
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load history file failed: %s", e)
     if days and len(records) > days:
         records = records[-days:]
     return records
@@ -138,7 +141,6 @@ def _run_failing_cases() -> dict:
             score_std = 0
             n_runs = 1
             badcase_votes = 0
-            all_dim_vals = {}
             if cache_path.exists():
                 try:
                     cached = _json.loads(cache_path.read_text(encoding="utf-8"))
@@ -156,8 +158,8 @@ def _run_failing_cases() -> dict:
                         avg_dims[name] = {"score": round(statistics.mean(vals), 1) if vals else 0, "comment": comment}
                         if len(vals) >= 2 and len(set(vals)) > 1:
                             dim_var[name] = round(statistics.stdev(vals), 2)
-                except Exception:
-                    pass
+                except Exception as e:
+                    _logger.warning("compute dimension stats failed: %s", e)
 
             entry = {
                 "case_name": r.case_name,
@@ -217,8 +219,8 @@ def _collect_stability() -> list[dict]:
                             full_user_prompt = run.get("user_prompt", "")
                         if not full_system_prompt:
                             full_system_prompt = run.get("system_prompt", "")
-                except Exception:
-                    pass
+                except Exception as e:
+                    _logger.warning("load run prompts failed: %s", e)
             cases.append({
                 "case_name": r.case_name,
                 "source": r.source,
@@ -235,7 +237,7 @@ def _collect_stability() -> list[dict]:
                 "cross_similarity": r.cross_similarity,
             })
     except Exception as e:
-        pass
+        _logger.warning("load cases failed: %s", e)
     return cases
 
 

--- a/scripts/import_account_history.py
+++ b/scripts/import_account_history.py
@@ -18,9 +18,9 @@
 """
 
 import argparse
-import json
+
 import sys
-import time
+
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/scripts/import_account_history_v2.py
+++ b/scripts/import_account_history_v2.py
@@ -6,7 +6,7 @@
 """
 
 import argparse
-import json
+
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/scripts/import_account_history_v3.py
+++ b/scripts/import_account_history_v3.py
@@ -6,7 +6,7 @@
 """
 
 import argparse
-import json
+
 import sys
 import time
 from pathlib import Path

--- a/scripts/import_weflow_exports.py
+++ b/scripts/import_weflow_exports.py
@@ -9,7 +9,7 @@
 
 import json
 import sys
-import time
+
 from collections import defaultdict
 from pathlib import Path
 

--- a/scripts/monitor_benchmark.py
+++ b/scripts/monitor_benchmark.py
@@ -16,11 +16,14 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+import logging
 
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 HISTORY_DIR = PROJECT_ROOT / "data" / "benchmark_history"
 HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+
+_logger = logging.getLogger(__name__)
 
 # 退化告警阈值
 ALERT_THRESHOLDS = {
@@ -79,7 +82,6 @@ def _load_metrics(filepath: Path) -> dict | None:
 
 def _save_snapshot(metrics: dict, prefix: str = ""):
     now = datetime.now()
-    ts = now.strftime("%Y-%m-%d_%H-%M")
     snapshot = {
         "timestamp": now.isoformat(),
         "date": now.strftime("%Y-%m-%d"),
@@ -100,8 +102,8 @@ def _save_snapshot(metrics: dict, prefix: str = ""):
             benchmarks=metrics,
             git_commit=snapshot["git_commit"],
         )
-    except Exception:
-        pass
+    except Exception as e:
+        _logger.warning("save snapshot failed: %s", e)
 
     return snapshot, filepath
 

--- a/scripts/rebuild_group_wiki.py
+++ b/scripts/rebuild_group_wiki.py
@@ -11,7 +11,7 @@
 
 import argparse
 import json
-import os
+
 import sys
 import time
 from pathlib import Path

--- a/scripts/run_daily_benchmark.py
+++ b/scripts/run_daily_benchmark.py
@@ -22,6 +22,7 @@ import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
+import logging
 
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -29,6 +30,8 @@ sys.path.insert(0, str(PROJECT_ROOT))
 HISTORY_DIR = PROJECT_ROOT / "data" / "benchmark_history"
 HISTORY_DIR.mkdir(parents=True, exist_ok=True)
 TREND_FILE = HISTORY_DIR / "trend.json"
+
+_logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -153,7 +156,6 @@ def _run_unread_badge(use_api: bool = False) -> dict:
             else:
                 tn += 1
 
-        total_valid = tp + fp + tn + fn
         precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
         f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
@@ -234,8 +236,8 @@ def _load_history(days: int = 30) -> list[dict]:
             data = json.loads(f.read_text(encoding="utf-8"))
             data["date"] = date_str
             records.append(data)
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load history file failed: %s", e)
     return records
 
 

--- a/scripts/sync_knowledge.py
+++ b/scripts/sync_knowledge.py
@@ -14,6 +14,9 @@
 import json
 import re
 from pathlib import Path
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 def parse_knowledge_source(md_path: Path) -> dict:
@@ -105,8 +108,8 @@ def update_aliases(people: list, aliases_path: Path):
     if aliases_path.exists():
         try:
             data = json.loads(aliases_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load aliases failed: %s", e)
 
     for p in people:
         name = p["name"]
@@ -132,8 +135,8 @@ def update_facts(people: list, facts_path: Path):
     if facts_path.exists():
         try:
             data = json.loads(facts_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load facts failed: %s", e)
 
     for p in people:
         name = p["name"]
@@ -156,8 +159,8 @@ def update_corrections(groups: list, corrections_path: Path):
     if corrections_path.exists():
         try:
             data = json.loads(corrections_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("load corrections failed: %s", e)
 
     for g in groups:
         name = g["name"]

--- a/scripts/test_custom_prompt.py
+++ b/scripts/test_custom_prompt.py
@@ -4,11 +4,14 @@
 import os, sys
 from pathlib import Path
 from datetime import datetime
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.session.global_store import GlobalStore
 from mem0 import Memory
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 
@@ -53,8 +56,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 full_context = "\n".join(lines)

--- a/scripts/test_mem0_one_group.py
+++ b/scripts/test_mem0_one_group.py
@@ -8,11 +8,14 @@ import os
 import sys
 from pathlib import Path
 from datetime import datetime
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.session.global_store import GlobalStore
 from mem0 import Memory
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 
@@ -69,8 +72,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 # 按embedding限制切分 chunk（每 chunk < 4000 字符，留安全余量）

--- a/scripts/test_skip_phase1.py
+++ b/scripts/test_skip_phase1.py
@@ -4,6 +4,7 @@
 import os, json, sys
 from pathlib import Path
 from datetime import datetime
+import logging
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -12,6 +13,8 @@ from mem0 import Memory
 from mem0.configs.prompts import ADDITIVE_EXTRACTION_PROMPT, generate_additive_extraction_prompt
 from mem0.memory.main import _build_session_scope
 from mem0.memory.utils import parse_messages
+
+_logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 
@@ -56,8 +59,8 @@ for m in messages:
     if ts:
         try:
             tstr = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
-        except:
-            pass
+        except Exception as e:
+            _logger.warning("timestamp conversion failed: %s", e)
     lines.append(f"[{tstr}] {m.sender}: {m.text}")
 
 full_context = "\n".join(lines)

--- a/scripts/verify_prompt_change.py
+++ b/scripts/verify_prompt_change.py
@@ -3,6 +3,7 @@
 
 import json, os, sys, sqlite3
 from pathlib import Path
+import logging
 
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -21,6 +22,8 @@ from src.utils.qwen_client import QwenClient
 from src.tools.tool_registry import get_registry
 from src.tools.builtin_tools import register_builtin_tools
 from src.memory import MemoryEngine
+
+_logger = logging.getLogger(__name__)
 
 llm = QwenClient()
 
@@ -134,7 +137,8 @@ for tick_id in TICK_IDS:
             try:
                 data = json.loads(final_reply.strip())
                 new_replies = data.get("replies", [])
-            except:
+            except Exception as e:
+                _logger.warning("parse final reply failed: %s", e)
                 new_replies = [final_reply.strip()]
         else:
             new_replies = [final_reply.strip()]

--- a/src/action/login_recovery.py
+++ b/src/action/login_recovery.py
@@ -12,9 +12,9 @@ from enum import Enum
 from typing import List, Optional
 
 import Quartz
-import AppKit
 
-from src.models.base import Rect, OCRTextElement, Point
+
+from src.models.base import Rect, OCRTextElement
 from src.ocr.vision_ocr import VisionOCREngine
 
 

--- a/src/badcase/case_db.py
+++ b/src/badcase/case_db.py
@@ -16,7 +16,7 @@ import json
 import logging
 import sqlite3
 import threading
-import time
+
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional

--- a/src/badcase/case_generator.py
+++ b/src/badcase/case_generator.py
@@ -8,9 +8,9 @@ CaseGenerator - 根据 draft 生成 benchmark case 代码
   P3: test_reply_quality_benchmark.py（多轮纠正，暂时复用 P2 文件）
 """
 
-import json
+
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
@@ -76,7 +76,6 @@ class CaseGenerator:
     def _generate_p2_case(self, draft: Dict) -> str:
         tick_id = draft["tick_id"]
         badcase_type = draft["judge_result"]["badcase_type"]
-        severity = draft["judge_result"].get("severity", "P1")
         reason = draft["judge_result"].get("reason", "")
         expected = draft["judge_result"].get("expected_behavior", "")
 

--- a/src/badcase/judge_worker.py
+++ b/src/badcase/judge_worker.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """JudgeWorker - 异步 badcase 判定，支持查证反思"""
 
-import json, logging, os, queue, re, sqlite3, subprocess, threading, time
-from dataclasses import dataclass
+import json, logging, queue, re, sqlite3, subprocess, threading
+
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 _logger = logging.getLogger("src.badcase.judge_worker")
 
@@ -333,8 +333,8 @@ class JudgeWorker:
                 tick_id,
             ))
             conn.commit(); conn.close()
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("judge db write failed: %s", e)
 
         if not judge_result.get("is_badcase"):
             return
@@ -400,7 +400,9 @@ class JudgeWorker:
         tick_ts = tick_data.get("created_at", "")
         if tick_ts:
             try: now = datetime.fromisoformat(tick_ts)
-            except: now = datetime.now()
+            except Exception as e:
+                _logger.warning("parse tick timestamp failed: %s", e)
+                now = datetime.now()
         else:
             now = datetime.now()
         current_time = now.isoformat()

--- a/src/bot/wechat_bot.py
+++ b/src/bot/wechat_bot.py
@@ -382,14 +382,6 @@ class WeChatBot:
                 if self.on_message:
                     self.on_message(msg, state)
 
-            latest = None
-            should_send = False
-            for msg in reversed(unreplied):
-                if self.policy.should_reply(msg, state):
-                    latest = msg
-                    should_send = True
-                    break
-
             # 收集所有需要回复的未读消息
             to_reply = [msg for msg in unreplied if self.policy.should_reply(msg, state)]
             if not to_reply:
@@ -467,8 +459,8 @@ class WeChatBot:
                 if conn:
                     try:
                         conn.close()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        self.logger.warning("close tick_log connection failed: %s", e)
             self.logger.log_decision(
                 tick_id, should_reply=True,
                 reason=f"触发回复条件 (未读 {len(unreplied)} 条，需回复 {len(to_reply)} 条，生成 {len(replies)} 条回复)",
@@ -785,7 +777,6 @@ class WeChatBot:
         result = self.sender.send(text, chat_name=chat_name)
         if result.success:
             norm = _normalize_chat_name(chat_name)
-            is_group = _is_group_chat_name(chat_name)
             # 创建一条虚拟的已回复消息记录，放入 pending 等感知层确认
             from src.models.base import ChatMessage, SenderType
             msg = ChatMessage(

--- a/src/capture/window_capture.py
+++ b/src/capture/window_capture.py
@@ -212,8 +212,8 @@ class WindowCapture:
                 try:
                     if os.path.getmtime(old) < cutoff:
                         os.remove(old)
-                except OSError:
-                    pass
+                except OSError as e:
+                    _logger.warning("cleanup old screenshot failed: %s", e)
         except Exception as e:
             _logger.debug("[WindowCapture] 清理旧截图失败: %s", e)
 

--- a/src/layout/layout_parser.py
+++ b/src/layout/layout_parser.py
@@ -3,14 +3,17 @@
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import numpy as np
 from PIL import Image
 from scipy import ndimage
+import logging
 
 from src.layout.profile import LayoutProfile
 from src.models.base import ChatListItem, OCRTextElement, Rect
+
+_logger = logging.getLogger(__name__)
 
 
 TIMESTAMP_PATTERNS = [
@@ -44,7 +47,6 @@ class LayoutParser:
     @staticmethod
     def clean_chat_name(text: str) -> str:
         """仅去除聊天列表中的时间戳后缀（如 '昨天 22:26'），时间戳是 UI 元素而非昵称。"""
-        import re
         text = re.sub(r'(昨天|今天)\s+\d{1,2}[:：]\d{2}$', '', text)
         text = re.sub(r'\s+\d{1,2}[:：]\d{2}$', '', text)
         return text.strip()
@@ -306,8 +308,8 @@ class LayoutParser:
                         red_pixels = np.sum(strict_red)
                         if red_pixels >= 50:
                             unread_for_group[idx] = "1"
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.warning("detect unread badge failed: %s", e)
 
         def _clean_nickname(text: str) -> str:
             """清理 OCR 产生的昵称污染：去掉噪声符号前缀和时间戳后缀。

--- a/src/llm/openclaw_client.py
+++ b/src/llm/openclaw_client.py
@@ -8,7 +8,7 @@
 import logging
 import os
 import time
-from typing import List, Dict, Any, Optional
+from typing import Optional
 
 
 def _get_openai_client():

--- a/src/logging/bot_logger.py
+++ b/src/logging/bot_logger.py
@@ -12,7 +12,7 @@ AI 使用指南：
 - 新增日志时，尽量使用便捷方法：log_tick_start / log_ocr / log_layout / log_decision / log_send
 """
 
-import os
+
 import json
 import logging
 import traceback

--- a/src/message/extractor.py
+++ b/src/message/extractor.py
@@ -39,7 +39,7 @@ class MessageExtractor:
         messages.extend(other_messages)
 
         # 3. 按 y 坐标排序
-        messages.sort(key=lambda m: self._message_y_position(m))
+        messages.sort(key=self._message_y_position)
 
         # 合并调试信息（不覆盖 _extract_other_messages 中设置的 clusters）
         self.debug_info.update({

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -2,9 +2,9 @@
 """L1 Domain Models - 基础数据类型"""
 
 from dataclasses import dataclass
-from datetime import datetime
+
 from enum import Enum
-from typing import Callable, Dict, FrozenSet, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Optional
 
 # 媒体消息类型常量，供各模块统一引用
 MEDIA_MESSAGE_TYPES: FrozenSet[str] = frozenset({"image", "sticker", "mixed", "link_card", "video"})

--- a/src/perception/smart_pipeline.py
+++ b/src/perception/smart_pipeline.py
@@ -369,7 +369,6 @@ class SmartPerceptionPipeline:
             )
             if curr_hash == self._last_hash:
                 skip_api = True
-                diff_ratio = 0.0
                 self._consecutive_low_diff += 1
                 _logger.info(
                     f"[SmartPipeline] 截图完全相同 (hash一致)，跳过API调用"

--- a/src/perception/weflow_pipeline.py
+++ b/src/perception/weflow_pipeline.py
@@ -384,8 +384,6 @@ class WeFlowPipeline:
             return self._chat_name_to_talker[cleaned]
 
         # 模糊匹配（应对 OCR 识别差异）
-        best_score = 0.0
-        best_talker = None
         for name, talker in self._chat_name_to_talker.items():
             # 简单包含匹配
             if name in chat_name or chat_name in name:

--- a/src/reply/generator.py
+++ b/src/reply/generator.py
@@ -5,10 +5,10 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from src.models.base import ChatMessage, MEDIA_MESSAGE_TYPES, SenderType
-from src.tools import get_registry, register_builtin_tools
+from src.tools import get_registry
 from src.reply.session_memory import SessionMemory, _extract_query_key
 
 _logger = logging.getLogger("src.reply.generator")
@@ -169,8 +169,6 @@ class ReplyGenerator:
             self._submit_to_judge(tick_id, [], unreplied, all_messages, is_group)
             return []
 
-        fallback_msg = unreplied[-1]
-
         if self.llm_client is None:
             self._submit_to_judge(tick_id, [], unreplied, all_messages, is_group)
             return []
@@ -272,7 +270,6 @@ class ReplyGenerator:
             messages[0]["content"] = self._hermes_system_prompt()
             print(f"[Hermes] 使用精简 system prompt，不传 tools")
         tool_round_count = 0  # 已执行的 tool 轮数
-        max_tool_rounds = 10  # 最多允许 10 轮 tool 调用（如先 stock_query 再 web_search）
 
         for attempt in range(max_retries + 1):
             start_time = time.time()
@@ -378,8 +375,8 @@ class ReplyGenerator:
                             try:
                                 query_key = _extract_query_key(tool_name, tool_args)
                                 self.session_memory.add_tool_result(chat_name, tool_name, query_key, str(result)[:1000])
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                _logger.warning("add tool result failed: %s", e)
 
                             # 记录工具调用（summary）
                             tool_calls.append({
@@ -1164,13 +1161,7 @@ class ReplyGenerator:
         # 未读消息（带去重检查：如果历史中已有相似消息且 Bot 已回复，标记为'可能已处理'）
         lines_local.append("[未读消息]（重点回复）")
         # 从历史中提取 Bot 已回复的消息文本（用于去重判断）
-        replied_in_history = set()
-        if all_messages:
-            for m in all_messages:
-                if m.sender_type == SenderType.SELF and m.reply_time and m.text:
-                    # 提取 Bot 回复之前最后一个非 Bot 消息的文本作为"已处理"标记
-                    pass
-            # 简化：如果[未读消息]中的某条在[历史消息]中能找到 Bot 的回复且 Bot 回复在未读消息时间之前
+        # 简化：如果[未读消息]中的某条在[历史消息]中能找到 Bot 的回复且 Bot 回复在未读消息时间之前
             # 则标记为"可能已回复"
 
         skipped_hint = []

--- a/src/tests/test_action.py
+++ b/src/tests/test_action.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """L4 Action Layer 单元测试"""
 
-import subprocess
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/src/tests/test_judge_quality_benchmark_v2.py
+++ b/src/tests/test_judge_quality_benchmark_v2.py
@@ -19,6 +19,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+import logging
 
 import pytest
 
@@ -41,6 +42,8 @@ CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 DB_PATH = PROJECT_ROOT / "data" / "cases.db"
 DEBUG_DIR = PROJECT_ROOT / "data" / "debug"
+
+_logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -116,8 +119,8 @@ def _load_gt_cases() -> List[JudgeBenchmarkCase]:
                 dbg_msgs = dbg.get("reply_llm_messages", []) or []
                 if dbg_msgs:
                     llm_messages = dbg_msgs
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.warning("load reply debug messages failed: %s", e)
 
         # fallback：用 raw_response 补充 assistant message，让 Judge 看到完整的 LLM 交互
         if len(llm_messages) <= 2:
@@ -157,8 +160,8 @@ def _load_gt_cases() -> List[JudgeBenchmarkCase]:
             try:
                 dbg = json.loads(debug_files[-1].read_text(encoding="utf-8"))
                 session_msgs = dbg.get("session_input_messages", []) or []
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.warning("load session debug messages failed: %s", e)
         if not session_msgs:
             # 从 user_prompt 的 [未读消息] 段粗略提取
             session_msgs = [{"sender": "unknown", "sender_type": "other", "text": up[:200]}]

--- a/src/tests/test_ocr_quality_benchmark.py
+++ b/src/tests/test_ocr_quality_benchmark.py
@@ -244,7 +244,7 @@ def _normalize_text(text: str, aggressive: bool = False) -> str:
         # 去除 markdown 标记
         text = re.sub(r'\*{1,2}|_{1,2}', '', text)
         # 去除常见 emoji
-        text = re.sub(r'[📱⚡️😂🤖💪👍🔥❤️✅❌👉👈]', '', text)
+        text = re.sub(r'[📱⚡️😂🤖💪👍🔥❤✅❌👉👈]', '', text)
         # 去除项目符号
         text = re.sub(r'^[•·\-]\s*', '', text, flags=re.MULTILINE)
         text = " ".join(text.split())

--- a/src/tests/test_qwen_client.py
+++ b/src/tests/test_qwen_client.py
@@ -4,6 +4,7 @@
 import os
 import pytest
 from unittest.mock import patch, MagicMock
+from urllib.parse import urlparse
 
 from src.utils.qwen_client import QwenClient
 
@@ -23,7 +24,8 @@ class TestQwenClientInit:
         }, clear=True):
             client = QwenClient()
             assert client.is_deepseek_official
-            assert "deepseek.com" in str(client.client.base_url)
+            parsed = urlparse(str(client.client.base_url))
+            assert parsed.hostname == "api.deepseek.com"
 
     def test_missing_api_key_raises(self):
         with patch.dict(os.environ, {}, clear=True):

--- a/src/tests/test_regression_fixes.py
+++ b/src/tests/test_regression_fixes.py
@@ -71,7 +71,6 @@ class TestUnreadDetectionFixes:
         from src.layout.profile import PROFILE_WECHAT_MAC_1760X1280
         from src.layout.layout_parser import LayoutParser
 
-        parser = LayoutParser(PROFILE_WECHAT_MAC_1760X1280)
         # 验证 _parse_chat_list 中的阈值范围
         # scale_x 约 0.97，所以 unread_x_min ~ 78, unread_x_max ~ 165
         # 未读角标 center.x 约 137，应在范围内

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -148,7 +148,6 @@ class TestBuiltinTools:
             assert mock_get.call_args[0][0].startswith("https://")
 
     def test_register_builtin_tools(self):
-        reg = ToolRegistry()
         register_builtin_tools()
         reg2 = get_registry()
         assert reg2.has("get_current_time")

--- a/src/tools/builtin_tools.py
+++ b/src/tools/builtin_tools.py
@@ -1,8 +1,8 @@
 """内置工具 - 时间、天气、搜索"""
 
-import json
+
 from datetime import datetime
-from typing import Dict, Any
+
 from urllib.parse import parse_qs, urlparse, unquote
 
 import requests
@@ -119,9 +119,10 @@ def _add_to_cache(url: str, text: str):
         del _PAGE_CACHE[oldest]
 
 
-def _search_keyword_in_text(text: str, keyword: str, results: list, is_fuzzy: bool = False, word: str = "") -> None:
+def _search_keyword_in_text(text: str, keyword: str, results: list, is_fuzzy: bool = False, word: str = "") -> list:
     """在 text 中查找 keyword（忽略大小写），将前后 200 字上下文加入 results。
     使用 str.find 替代正则，避免 re 模块依赖。
+    返回传入的 results 列表（已追加匹配结果）。
     """
     lower_text = text.lower()
     lower_kw = keyword.lower()
@@ -140,8 +141,9 @@ def _search_keyword_in_text(text: str, keyword: str, results: list, is_fuzzy: bo
         label = f"[关键词'{word}' 位置 {idx}]" if is_fuzzy else f"[位置 {idx}]"
         results.append(f"{label}: {ctx}")
         if len(results) >= 5:
-            return
+            return results
         pos = idx + len(keyword)
+    return results
 
 
 def _browse_url(url: str = "") -> str:
@@ -170,7 +172,8 @@ def _browse_url(url: str = "") -> str:
 
         # 2. 提取正文：按优先级尝试
         body = ""
-        if "mp.weixin.qq.com" in url:
+        parsed_url = urlparse(url)
+        if parsed_url.hostname == "mp.weixin.qq.com":
             # 微信公众号文章
             content_div = soup.find("div", id="js_content")
             if content_div:
@@ -219,12 +222,12 @@ def _search_in_page(url: str = "", keyword: str = "") -> str:
     text = _PAGE_CACHE[url]
     # 查找关键词位置，返回前后各 200 字的上下文
     results = []
-    _search_keyword_in_text(text, keyword, results, is_fuzzy=False)
+    results = _search_keyword_in_text(text, keyword, results, is_fuzzy=False)
     if not results:
         # 模糊搜索：按空格拆词
         words = keyword.split()
         for w in words:
-            _search_keyword_in_text(text, w, results, is_fuzzy=True, word=w)
+            results = _search_keyword_in_text(text, w, results, is_fuzzy=True, word=w)
             if results:
                 break
     if not results:

--- a/src/tools/print_3d_tools.py
+++ b/src/tools/print_3d_tools.py
@@ -351,8 +351,8 @@ def print3d_get_printer_status(ip: str = "", access_code: str = "", serial: str 
             data = json.loads(msg.payload)
             if "print" in data:
                 status_data.update(data["print"])
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("parse mqtt payload failed: %s", e)
 
     client.on_connect = on_connect
     client.on_message = on_message

--- a/src/utils/chat_utils.py
+++ b/src/utils/chat_utils.py
@@ -4,7 +4,7 @@
 所有涉及 chat_name 的处理逻辑统一放在这里，禁止各模块自己写正则。
 """
 
-from typing import Optional
+
 
 
 def _is_group_chat_name(chat_name: str) -> bool:

--- a/src/utils/debug_logger.py
+++ b/src/utils/debug_logger.py
@@ -11,6 +11,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -308,8 +311,8 @@ class DebugLogger:
             all_files = sorted(prompts_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True)
             for old_file in all_files[50:]:
                 old_file.unlink()
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.warning("cleanup old debug logs failed: %s", e)
 
         return
 

--- a/src/utils/llm_client.py
+++ b/src/utils/llm_client.py
@@ -5,8 +5,8 @@ Kimi LLM 客户端
 """
 
 import os
-import sys
-from pathlib import Path
+
+
 from typing import List, Dict
 
 try:
@@ -51,7 +51,6 @@ class KimiClient:
         # 新接口：直接传入 messages 列表
         if messages is not None:
             conv_messages = list(messages)
-            user_id = user_id or "default"
         else:
             # 旧接口：使用 user_id + message
             if user_id is None or message is None:

--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -108,7 +108,6 @@ def extract_context_around_keywords(
 
     # 在 max_chars 预算内取窗口，优先匹配密度高的
     result_parts = []
-    used_chars = 0
     budget = max_chars
     last_end = 0
 

--- a/tests_integration/regression_suite.py
+++ b/tests_integration/regression_suite.py
@@ -140,8 +140,8 @@ def test_layout_extraction(reporter):
 
         try:
             profile = PROFILE_WECHAT_MAC_1760X1280
-            parser = LayoutParser(profile)
-            extractor = MessageExtractor(profile)
+            LayoutParser(profile)
+            MessageExtractor(profile)
             reporter.ok(f"{name} 的布局解析器可实例化")
         except Exception as e:
             reporter.fail(f"{name} 布局解析异常: {e}")


### PR DESCRIPTION
This PR addresses the remaining ~120 open Code Scanning alerts that were not covered by #24.

### Changes
- Remove ~40 unused imports
- Remove ~24 unused local variables
- Convert bare/empty except blocks to  with logging (~48 alerts)
- Fix remaining warnings: incomplete URL substring sanitization, unreachable statement, regex duplicate, unnecessary lambda, repeated import, mixed returns

### Verification
-  passed for all 53 modified files

### Notes
- No functional logic changes beyond exception handling logging and dead-code removal.
- The single  error was already fixed in the previous PR.