### PR TITLE
docs: merge input layer into perception layer and add history init arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@
 
 ```mermaid
 graph LR
-    subgraph Input["输入层"]
-        C[窗口截图]
-    end
-
     subgraph Perception["感知层"]
+        C[窗口截图]
         P[视觉理解 + 布局解析]
+        W[全量聊天记录初始化]
     end
 
     subgraph Reasoning["推理层"]
@@ -45,6 +43,7 @@ graph LR
     R -->|ActionResult| A
     A -->|反馈| M
     M -->|上下文| R
+    W -->|全量聊天记录初始化| M
     A -->|生产数据| D
     D -->|质量反馈| R
 ```


### PR DESCRIPTION
将 README 架构图中的"输入层"并入"感知层"，并补全"全量聊天记录初始化 → 记忆系统"的箭头。\n\n- 合并前：输入层（窗口截图）→ 感知层（视觉理解 + 布局解析）\n- 合并后：感知层包含窗口截图、视觉理解 + 布局解析、全量聊天记录初始化\n- 新增箭头 W[全量聊天记录初始化] -- 全量聊天记录初始化 --> M[LLM Wiki + 向量数据库]