### PR TITLE
fix: initialize tools list to silence CodeQL alert

### DIFF
--- a/src/tests/test_reply_stability_benchmark.py
+++ b/src/tests/test_reply_stability_benchmark.py
@@ -132,6 +132,7 @@ def _reply_similarity(replies: list[str]) -> float:
 def run_benchmark(use_api: bool = False, api_key: str | None = None, n_generations: int = 3) -> list[StabilityResult]:
     cases = _load_cases()
     results: list[StabilityResult] = []
+    tools: list[dict] = []
 
     if use_api:
         # 加载 .env（与 run_bot.py 相同）


### PR DESCRIPTION
修复 Code Scanning 剩余 open alert (#271)：\n\n- 在 run_benchmark 函数入口初始化 tools: list[dict] = []\n- 避免 use_api=False 时 CodeQL 误判 llm.chat(messages=..., tools=tools, ...) 中的 tools 可能未初始化\n\n该改动不影响实际逻辑（use_api=True 时 tools 会被立即覆盖为 registry 的 schemas）。