### PR TITLE
docs: add MIT License and move Quick Start to the top

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 王芊
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,38 @@
 ![CI](https://github.com/wq19901103wq/wechat-mac-rpa/actions/workflows/ci.yml/badge.svg)
 ![Quality](https://github.com/wq19901103wq/wechat-mac-rpa/actions/workflows/quality.yml/badge.svg)
 ![CodeQL](https://github.com/wq19901103wq/wechat-mac-rpa/actions/workflows/codeql.yml/badge.svg)
+![License](https://img.shields.io/badge/License-MIT-blue.svg)
 
 基于**多模态视觉感知**与**LLM Agent**的 macOS 微信自动化框架。不是协议逆向，不是 Hook，不碰微信数据库——我们把微信当作纯黑盒 GUI 应用，用计算机视觉读取界面，用大语言模型理解对话，用系统级自动化操作界面。微信更新 UI 只是换了一套视觉输入，不需要追着协议跑。
 
 核心设计：**感知 → 推理 → 行动 → 记忆 → 数据飞轮**，五个子系统构成完整的认知闭环。每一次认知循环的完整链路都被结构化日志逐条记录，形成**可追溯、可回归、可量化**的生产质量资产。
+
+---
+
+## 快速开始
+
+- **环境**：macOS 12+，Python 3.10+，微信 Mac 版
+- **依赖**：`pip install -r requirements.txt`
+- **配置**：复制 `.env.example` 为 `.env`，填入 API Key
+- **启动**：`python3 run_bot.py`
+- **管理后台（LaunchAgent 常驻）**：
+  ```bash
+  # 首次加载（用户登录时自动启动，崩溃自动重启）
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wechat-mac-rpa.admin.plist
+  launchctl enable gui/$(id -u)/com.wechat-mac-rpa.admin
+  launchctl kickstart gui/$(id -u)/com.wechat-mac-rpa.admin
+  ```
+  常用操作：
+  - 查看状态：`launchctl list | grep com.wechat-mac-rpa.admin`
+  - 手动重启：`launchctl kickstart -k gui/$(id -u)/com.wechat-mac-rpa.admin`
+  - 停止服务：`launchctl bootout gui/$(id -u)/com.wechat-mac-rpa.admin`
+  - 日志：`tail -f logs/admin-launchd.log logs/admin.log`
+  - 前台调试用：`python3 scripts/admin.py`
+- **测试**：`python3 -m pytest src/tests/test_*_benchmark.py -v`
+- **OCR Benchmark**：`python3 src/tests/test_ocr_quality_benchmark.py`
+- **生成报告**：`python3 scripts/generate_ocr_benchmark_report.py`
+
+详细安装与配置指南见 `docs/01-quickstart/AI_QUICKSTART.md`。
 
 ---
 
@@ -275,33 +303,6 @@ Judge 一旦可信，回路二就可以大规模自动化运转，**人工不再
 
 ---
 
-## 快速开始
-
-- **环境**：macOS 12+，Python 3.10+，微信 Mac 版
-- **依赖**：`pip install -r requirements.txt`
-- **配置**：复制 `.env.example` 为 `.env`，填入 API Key
-- **启动**：`python3 run_bot.py`
-- **管理后台（LaunchAgent 常驻）**：
-  ```bash
-  # 首次加载（用户登录时自动启动，崩溃自动重启）
-  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wechat-mac-rpa.admin.plist
-  launchctl enable gui/$(id -u)/com.wechat-mac-rpa.admin
-  launchctl kickstart gui/$(id -u)/com.wechat-mac-rpa.admin
-  ```
-  常用操作：
-  - 查看状态：`launchctl list | grep com.wechat-mac-rpa.admin`
-  - 手动重启：`launchctl kickstart -k gui/$(id -u)/com.wechat-mac-rpa.admin`
-  - 停止服务：`launchctl bootout gui/$(id -u)/com.wechat-mac-rpa.admin`
-  - 日志：`tail -f logs/admin-launchd.log logs/admin.log`
-  - 前台调试用：`python3 scripts/admin.py`
-- **测试**：`python3 -m pytest src/tests/test_*_benchmark.py -v`
-- **OCR Benchmark**：`python3 src/tests/test_ocr_quality_benchmark.py`
-- **生成报告**：`python3 scripts/generate_ocr_benchmark_report.py`
-
-详细安装与配置指南见 `docs/01-quickstart/AI_QUICKSTART.md`。
-
----
-
 ## 工程基础设施
 
 - **Benchmark Dashboard**：自动生成可视化报告，汇总各 benchmark 的历史趋势与当前状态
@@ -394,6 +395,12 @@ wechat-mac-rpa/
 | [项目进度](docs/03-guides/PROJECT_STATUS.md) | 当前状态、活跃问题、benchmark 结果 |
 | [性能优化 Spec](docs/02-architecture/specs/PERFORMANCE_SPEC.md) | 全链路 profiling 点、瓶颈分析、优化方案 |
 | [踩坑记录](docs/04-troubleshooting/LESSONS_LEARNED.md) | 历史教训、常见错误模式 |
+
+---
+
+## License
+
+本项目采用 [MIT License](LICENSE) 开源。
 
 ---
 


### PR DESCRIPTION
1. **新增 MIT License**\n   - 创建 LICENSE 文件\n   - README 顶部添加 License badge\n   - 在免责声明前新增 License 章节\n\n2. **快速开始前置**\n   - 将 快速开始 章节从系统架构之后移到 README 最前面（标题 + 简介之后）\n   - 让新用户先看到如何跑起来，再阅读架构细节