### PR TITLE
docs: detail the architecture overview diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,24 @@ graph LR
     end
 
     subgraph Reasoning["推理层"]
-        R[去重 → 路由 → Agent]
+        Dedup[LCS 跨 tick 去重]
+        Router[Skills 路由]
+        Agent[轻量化 Agent<br/>ReAct 循环]
+        Hermes[Hermes<br/>长上下文推理]
+        Tools[工具层<br/>search_memory / web_search / browse_url]
     end
 
     subgraph Action["行动层"]
-        A[UI 交互抽象]
+        Reply[消息回复]
+        Switch[切换未读聊天]
+        File[文件/图片发送]
+        Recovery[登录恢复]
     end
 
     subgraph Memory["记忆层"]
-        M[LLM Wiki + 向量数据库]
+        WM[工作记忆<br/>最近 N 条原文]
+        SM[会话记忆<br/>人物卡 / 关系 / 偏好]
+        LM[长期记忆<br/>LLM Wiki + 向量数据库]
     end
 
     subgraph Flywheel["数据飞轮"]
@@ -67,13 +76,32 @@ graph LR
     end
 
     C --> P
-    P -->|PerceptionResult| R
-    R -->|ActionResult| A
-    A -->|反馈| M
-    M -->|上下文| R
-    W -->|全量聊天记录初始化| M
-    A -->|生产数据| D
-    D -->|质量反馈| R
+    P -->|PerceptionResult| Dedup
+    Dedup --> Router
+    Router -->|日常对话| Agent
+    Router -->|复杂 Skill| Hermes
+
+    Agent --> Tools
+    Tools -->|search_memory| LM
+    Tools -->|web_search / browse_url| Web[(外部网络)]
+
+    WM -->|上下文| Agent
+    SM -->|上下文| Agent
+    LM -->|来源| SM
+
+    Agent -->|ActionResult| Reply
+    Hermes -->|ActionResult| Reply
+    Agent --> Switch
+    Agent --> Recovery
+    Agent --> File
+
+    Reply -->|反馈| WM
+    Reply -->|反馈| SM
+    Reply -->|反馈| LM
+    W -->|全量聊天记录初始化| LM
+
+    Reply -->|生产数据| D
+    D -->|质量反馈| Agent
 ```
 
 ---


### PR DESCRIPTION
细化系统架构总览图，让五层认知闭环的内部结构更清晰：\n\n- **感知层**：保留窗口截图、视觉理解、全量聊天记录初始化\n- **推理层**：拆分为 LCS 去重 → Skills 路由 → 轻量化 Agent / Hermes，新增工具层节点\n- **工具层**：search_memory / web_search / browse_url，search_memory 直连长期记忆\n- **行动层**：拆分为消息回复、切换未读聊天、文件/图片发送、登录恢复\n- **记忆层**：拆分为工作记忆、会话记忆、长期记忆\n- 保留数据飞轮与推理/记忆层的反馈箭头