### PR TITLE
docs: revert architecture overview diagram to simple version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,11 @@ graph LR
     end
 
     subgraph Action["行动层"]
-        Reply[消息回复]
-        Switch[切换未读聊天]
-        File[文件/图片发送]
-        Recovery[登录恢复]
+        A[UI 交互抽象]
     end
 
     subgraph Memory["记忆层"]
-        WM[工作记忆<br/>最近 N 条原文]
-        SM[会话记忆<br/>人物卡 / 关系 / 偏好]
-        LM[长期记忆<br/>LLM Wiki + 向量数据库]
+        M[LLM Wiki + 向量数据库]
     end
 
     subgraph Flywheel["数据飞轮"]
@@ -73,21 +68,11 @@ graph LR
 
     C --> P
     P -->|PerceptionResult| R
-    R -->|ActionResult| Reply
-    R --> Switch
-    R --> File
-    R --> Recovery
-
-    WM -->|上下文| R
-    SM -->|上下文| R
-    LM -->|来源| SM
-
-    Reply -->|反馈| WM
-    Reply -->|反馈| SM
-    Reply -->|反馈| LM
-    W -->|全量聊天记录初始化| LM
-
-    Reply -->|生产数据| D
+    R -->|ActionResult| A
+    A -->|反馈| M
+    M -->|上下文| R
+    W -->|全量聊天记录初始化| M
+    A -->|生产数据| D
     D -->|质量反馈| R
 ```
 


### PR DESCRIPTION
根据反馈，将系统架构总览图恢复为简洁版本，避免过度细化导致可读性下降：\n\n- 推理层：去重 → 路由 → Agent\n- 行动层：UI 交互抽象\n- 记忆层：LLM Wiki + 向量数据库\n- 感知层保留窗口截图 / 视觉理解 / 全量聊天记录初始化\n- 保留 W → M 的全量聊天记录初始化箭头\n- 保留当前数据飞轮描述