### PR TITLE
fix: sync case_db schema with code and lazy-load benchmark cases

### DIFF
--- a/src/badcase/case_db.py
+++ b/src/badcase/case_db.py
@@ -56,14 +56,37 @@ CREATE TABLE IF NOT EXISTS tick_log (
 CREATE TABLE IF NOT EXISTS cases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     draft_id TEXT UNIQUE NOT NULL, tick_id INTEGER, chat_name TEXT,
+    source TEXT DEFAULT 'committed',
     status TEXT DEFAULT 'pending', badcase_type TEXT, severity TEXT,
     confidence REAL, overall_score REAL, is_badcase INTEGER DEFAULT 0,
-    screenshot_path TEXT, judge_reason TEXT, created_at TEXT DEFAULT (datetime('now','localtime'))
+    auto_commit INTEGER DEFAULT 0,
+    screenshot_path TEXT, judge_reason TEXT, expected_behavior TEXT,
+    committed_at TEXT, committed_by TEXT,
+    dismissed_at TEXT, dismiss_reason TEXT,
+    created_at TEXT DEFAULT (datetime('now','localtime')),
+    git_commit TEXT
 );
 
 CREATE TABLE IF NOT EXISTS case_prompts (
     case_id INTEGER PRIMARY KEY REFERENCES cases(id),
-    system_prompt TEXT, user_prompt TEXT
+    system_prompt TEXT, user_prompt TEXT,
+    tools_context TEXT, memory_injected TEXT
+);
+
+CREATE TABLE IF NOT EXISTS case_tool_calls (
+    case_id INTEGER REFERENCES cases(id),
+    call_order INTEGER,
+    tool_name TEXT,
+    arguments TEXT,
+    UNIQUE(case_id, call_order)
+);
+
+CREATE TABLE IF NOT EXISTS case_llm_messages (
+    case_id INTEGER REFERENCES cases(id),
+    message_order INTEGER,
+    role TEXT,
+    content_preview TEXT,
+    UNIQUE(case_id, message_order)
 );
 
 CREATE TABLE IF NOT EXISTS case_dimensions (
@@ -237,6 +260,59 @@ class CaseDB:
                 conn.commit()
             except Exception as e:
                 _logger.warning("[CaseDB] 添加 messages_json 列失败: %s", e)
+
+            # 迁移：补全 cases 表缺失列
+            try:
+                cur = conn.execute("PRAGMA table_info(cases)")
+                columns = {row[1] for row in cur.fetchall()}
+                for col, dtype in [
+                    ("source", "TEXT DEFAULT 'committed'"),
+                    ("auto_commit", "INTEGER DEFAULT 0"),
+                    ("expected_behavior", "TEXT"),
+                    ("committed_at", "TEXT"),
+                    ("committed_by", "TEXT"),
+                    ("dismissed_at", "TEXT"),
+                    ("dismiss_reason", "TEXT"),
+                    ("git_commit", "TEXT"),
+                ]:
+                    if col not in columns:
+                        conn.execute(f"ALTER TABLE cases ADD COLUMN {col} {dtype}")
+                conn.commit()
+            except Exception as e:
+                _logger.warning("[CaseDB] cases 表迁移失败: %s", e)
+
+            # 迁移：补全 case_prompts 表缺失列
+            try:
+                cur = conn.execute("PRAGMA table_info(case_prompts)")
+                columns = {row[1] for row in cur.fetchall()}
+                for col, dtype in [("tools_context", "TEXT"), ("memory_injected", "TEXT")]:
+                    if col not in columns:
+                        conn.execute(f"ALTER TABLE case_prompts ADD COLUMN {col} {dtype}")
+                conn.commit()
+            except Exception as e:
+                _logger.warning("[CaseDB] case_prompts 表迁移失败: %s", e)
+
+            # 迁移：创建 case_tool_calls / case_llm_messages 表
+            try:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS case_tool_calls (
+                        case_id INTEGER REFERENCES cases(id),
+                        call_order INTEGER,
+                        tool_name TEXT,
+                        arguments TEXT,
+                        UNIQUE(case_id, call_order)
+                    );
+                    CREATE TABLE IF NOT EXISTS case_llm_messages (
+                        case_id INTEGER REFERENCES cases(id),
+                        message_order INTEGER,
+                        role TEXT,
+                        content_preview TEXT,
+                        UNIQUE(case_id, message_order)
+                    );
+                """)
+                conn.commit()
+            except Exception as e:
+                _logger.warning("[CaseDB] 创建 case_tool_calls / case_llm_messages 表失败: %s", e)
 
             conn.close()
 

--- a/src/tests/test_judge_quality_benchmark.py
+++ b/src/tests/test_judge_quality_benchmark.py
@@ -574,7 +574,15 @@ _FALLBACK_CASES: List[JudgeBenchmarkCase] = [
     _CASE_NORMAL, _CASE_NORMAL2, _CASE_NORMAL3, _CASE_NORMAL4, _CASE_NORMAL5,
 ]
 
-BENCHMARK_CASES: List[JudgeBenchmarkCase] = _load_cases_from_db()
+_BENCHMARK_CASES_CACHE: List[JudgeBenchmarkCase] | None = None
+
+
+def _get_benchmark_cases() -> List[JudgeBenchmarkCase]:
+    """懒加载 benchmark cases，避免测试收集阶段访问真实数据库。"""
+    global _BENCHMARK_CASES_CACHE
+    if _BENCHMARK_CASES_CACHE is None:
+        _BENCHMARK_CASES_CACHE = _load_cases_from_db()
+    return _BENCHMARK_CASES_CACHE
 
 
 # =============================================================================
@@ -628,7 +636,7 @@ def run_benchmark(use_api: bool = False, api_key: str | None = None, n_runs: int
             os.environ["DASHSCOPE_API_KEY"] = api_key
             worker = JudgeWorker()
 
-    for case in BENCHMARK_CASES:
+    for case in _get_benchmark_cases():
         all_runs = []
 
         if use_api:
@@ -805,11 +813,12 @@ def main():
     parser.add_argument("--n-runs", type=int, default=3, help="每个 case 跑几次取平均（默认 3）")
     args = parser.parse_args()
 
-    print(f"🧑‍⚖️  Judge Quality Benchmark — {len(BENCHMARK_CASES)} 真实生产 case")
+    cases = _get_benchmark_cases()
+    print(f"🧑‍⚖️  Judge Quality Benchmark — {len(cases)} 真实生产 case")
     print(f"   模式: {'真实 API' if args.run_api else '缓存回归'} × {args.n_runs} runs")
-    print(f"   badcase: {sum(1 for c in BENCHMARK_CASES if c.ground_truth_is_badcase)}")
-    print(f"   normal:  {sum(1 for c in BENCHMARK_CASES if not c.ground_truth_is_badcase)}")
-    for c in BENCHMARK_CASES:
+    print(f"   badcase: {sum(1 for c in cases if c.ground_truth_is_badcase)}")
+    print(f"   normal:  {sum(1 for c in cases if not c.ground_truth_is_badcase)}")
+    for c in cases:
         print(f"     [{c.case_name}] {c.category} ← {c.source_draft_id or c.source_chat_name}")
     print()
 


### PR DESCRIPTION
修复数据库 schema 与代码不一致的问题。\n\n## 问题\n- case_db.py 的 SCHEMA_SQL 中缺少代码实际使用的表和列\n- 本地测试收集阶段报错：no such table: case_tool_calls\n\n## 修复\n1. **补全 cases 表列**：source / auto_commit / expected_behavior / committed_at / committed_by / dismissed_at / dismiss_reason / git_commit\n2. **补全 case_prompts 表列**：tools_context / memory_injected\n3. **新增缺失表**：case_tool_calls / case_llm_messages\n4. **迁移逻辑**：在 _init_schema 中为已有数据库自动补全上述列和表\n5. **测试解耦**：将 test_judge_quality_benchmark.py 的 BENCHMARK_CASES 改为 _get_benchmark_cases() 懒加载，避免测试收集阶段访问真实数据库