### PR TITLE
fix: GlobalStore weflow mode and max_messages trimming

### DIFF
--- a/src/session/global_store.py
+++ b/src/session/global_store.py
@@ -395,7 +395,7 @@ class GlobalStore:
             self._dirty.add(chat_name)
 
         # 选择去重策略
-        if mode in ("weflow", "hybrid") and messages and getattr(messages[0], "local_id", None) is not None:
+        if mode in ("weflow", "hybrid"):
             _logger.info("[GlobalStore] %s 使用 WeFlow 精确去重 (%d 条)", chat_name, len(messages))
             new_messages = self._merge_tick_weflow(chat_name, messages)
         else:
@@ -408,6 +408,15 @@ class GlobalStore:
             new_msg = replace(msg, chat_name=chat_name)
             state.messages.append(new_msg)
             state._msg_ids.add(_msg_id(chat_name, new_msg, is_group))
+
+        # 裁剪历史消息，避免无限增长
+        if len(state.messages) > self.max_messages:
+            state.messages = state.messages[-self.max_messages:]
+            state._msg_ids = {
+                _msg_id(chat_name, m, state.is_group)
+                for m in state.messages
+            }
+            self._dirty.add(chat_name)
 
         # 收集所有未回复的消息（按时间顺序）
         unreplied = [


### PR DESCRIPTION
修复 src/tests/test_global_store.py 中两个失败的测试。\n\n## 修复内容\n\n1. **WeFlow 模式判断优化**\n   - 原代码要求 messages[0] 必须有 local_id 才使用 _merge_tick_weflow\n   - 当后续 tick 中只有 bot 手动注入的消息（无 local_id）时，会错误走 LCS 路径，导致无法更新已有 bot 消息的 reply_time\n   - 修复后：只要 mode 为 weflow/hybrid 就使用 _merge_tick_weflow\n\n2. **历史消息裁剪**\n   - 原代码 merge_tick 后从不裁剪，max_messages 设置失效\n   - 修复后：当 state.messages 超过 max_messages 时，保留最近 N 条并重新计算 _msg_ids\n\n## 验证\n\npython3 -m pytest src/tests/test_global_store.py -v\n# 19 passed