### PR TITLE
fix: prevent switching to service accounts and verify chat switch

### DIFF
--- a/src/bot/wechat_bot.py
+++ b/src/bot/wechat_bot.py
@@ -605,19 +605,24 @@ class WeChatBot:
                 QwenClient.log_token_stats(self.logger)
             time.sleep(interval)
 
-    def _recover_from_non_chat_view(self, result: PerceptionResult) -> bool:
+    def _recover_from_non_chat_view(self, result: PerceptionResult, force: bool = False) -> bool:
         """当当前视图不是普通聊天窗口时（如服务号/公众号列表），尝试 Esc 返回。
 
         检测依据：chat_name 为空且左侧聊天列表不可见。此时按 Esc 通常能
         从服务号/公众号/文章列表退回到聊天列表。
+
+        Args:
+            result: 感知结果
+            force: 是否强制触发（忽略 chat_name/chat_list_items 检测）。
+                   用于点击后验证失败时的主动恢复。
         """
-        if result.chat_name:
+        if not force and result.chat_name:
             return False
-        if result.chat_list_items:
+        if not force and result.chat_list_items:
             # 左侧聊天列表可见，说明是普通聊天视图（可能只是当前聊天名没识别到）
             return False
 
-        self.logger.warning("[Recovery] 当前不在聊天视图（chat_name 为空且列表不可见），尝试 Esc 返回")
+        self.logger.warning("[Recovery] 当前不在聊天视图，尝试 Esc 返回")
         try:
             subprocess.run(
                 ["osascript", "-e", 'tell application "System Events" to key code 53'],
@@ -763,14 +768,43 @@ class WeChatBot:
 
         self.logger.info(f"[WeFlow] 准备点击 '{target_item.nickname}' at ({target_item.rect.x},{target_item.rect.y})")
         clicked = clicker.click_item(target_item)
-        if clicked:
-            self._last_switch_target = target_norm
-            self._last_switch_time = now
-            self.logger.info(f"🔄 切换聊天: {target_name!r} (未读 {target_unread})")
-            self.debug_logger.log_bot_decision(switch_target=target_name, switch_reason=f"未读 {target_unread}")
-            return target_name
-        self.logger.info(f"[WeFlow] 点击失败: '{target_item.nickname}'")
-        return ""
+        if not clicked:
+            self.logger.info(f"[WeFlow] 点击失败: '{target_item.nickname}'")
+            return ""
+
+        # 点击后验证：重新感知确认是否真的切换到了目标聊天
+        try:
+            verify_result = self.perception.perceive()
+            verify_chat = _normalize_chat_name(verify_result.chat_name or "")
+            if verify_chat == target_norm:
+                self._last_switch_target = target_norm
+                self._last_switch_time = now
+                self.logger.info(f"🔄 切换聊天: {target_name!r} (未读 {target_unread})")
+                self.debug_logger.log_bot_decision(switch_target=target_name, switch_reason=f"未读 {target_unread}")
+                return target_name
+
+            self.logger.warning(
+                f"[Switch] 点击后未切换到目标聊天，目标={target_name!r}，当前={verify_result.chat_name!r}，尝试 Esc 恢复"
+            )
+            recovered = self._recover_from_non_chat_view(verify_result, force=True)
+            if recovered:
+                # 重试一次
+                clicked = clicker.click_item(target_item)
+                if clicked:
+                    verify_result = self.perception.perceive()
+                    verify_chat = _normalize_chat_name(verify_result.chat_name or "")
+                    if verify_chat == target_norm:
+                        self._last_switch_target = target_norm
+                        self._last_switch_time = now
+                        self.logger.info(f"🔄 切换聊天（重试成功）: {target_name!r} (未读 {target_unread})")
+                        self.debug_logger.log_bot_decision(switch_target=target_name, switch_reason=f"未读 {target_unread}")
+                        return target_name
+
+            self.logger.warning(f"[Switch] 切换失败，放弃: {target_name!r}")
+            return ""
+        except Exception as e:
+            self.logger.warning(f"[Switch] 点击后验证异常: {e}")
+            return ""
 
     def send_to_chat(self, chat_name: str, text: str) -> ActionResult:
         """外部系统调用此接口主动发消息到指定聊天。"""

--- a/src/layout/layout_parser.py
+++ b/src/layout/layout_parser.py
@@ -374,6 +374,10 @@ class LayoutParser:
                 )
             )
 
+        # 过滤微信固定入口，避免 Bot 误点击服务号/订阅号后无法返回
+        _BLOCKED_ENTRIES = {"订阅号", "服务号", "公众号"}
+        items = [item for item in items if item.nickname not in _BLOCKED_ENTRIES]
+
         self.debug_info["chat_list"] = {
             "groups": [[e.text for e in g] for g in groups],
             "group_anchor_y": group_anchor_y,


### PR DESCRIPTION
解决 Bot 切换聊天时误点服务号/订阅号后无法返回的问题。\n\n## 改动\n\n1. **过滤聊天列表固定入口**（layout_parser.py）\n   - 过滤掉 订阅号 / 服务号 / 公众号，避免 Bot 把它们当作普通聊天点击\n\n2. **点击后验证**（wechat_bot.py）\n   - 点击目标聊天后，重新调用 perception.perceive() 验证当前聊天名\n   - 如果当前聊天名不等于目标聊天名，强制触发 Esc 恢复并重试一次\n   - 重试仍失败则放弃本次切换，避免卡死在非聊天视图\n\n3. **增强恢复机制**\n   - _recover_from_non_chat_view 增加 force 参数\n   - 点击验证失败时可强制触发 Esc，不再受 chat_list_items 是否可见的限制\n\n## 验证\n\npython3 -m pytest src/tests/test_chat_list_clicker.py src/tests/test_layout_parser.py src/tests/test_bot.py -q\n# 15 passed, 10 skipped