### PR TITLE
fix: replace broken star-history embed with GitHub Star Tracker

### DIFF
--- a/.github/workflows/star-tracker.yml
+++ b/.github/workflows/star-tracker.yml
@@ -1,0 +1,18 @@
+name: Track Stars
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: fbuireu/github-star-tracker@v1
+        with:
+          github-token: ${{ secrets.STAR_TRACKER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ erDiagram
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wq19901103wq/wechat-mac-rpa&type=Date)](https://star-history.com/#wq19901103wq/wechat-mac-rpa&Date)
+![Star History](https://raw.githubusercontent.com/wq19901103wq/wechat-mac-rpa/star-tracker-data/charts/star-history.svg)
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace the broken `api.star-history.com` SVG embed with a self-hosted chart generated by [GitHub Star Tracker](https://github.com/fbuireu/github-star-tracker).
- Add `.github/workflows/star-tracker.yml` to generate the chart daily and on demand.

## Why
`api.star-history.com/svg` currently returns 503 for this repo (and others like `torvalds/linux`, `facebook/react`). The chart image in the README is broken for new visitors.

## After merge
1. Add a repository secret named `STAR_TRACKER_TOKEN` (classic PAT with `public_repo` scope).
2. Run the `Track Stars` workflow manually once.
3. The `star-tracker-data` branch will be created with `charts/star-history.svg`, and the README image will render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)