### PR TITLE
feat: add persona few-shot builder, split dev deps, and fix runtime regressions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ DASHSCOPE_API_KEY=sk-your-key-here
 # false=回退到纯本地 VisionPipeline
 USE_MULTIMODAL_OCR=true
 
+# 本人真实聊天 few-shot（本地动态召回，默认启用）
+# ENABLE_PERSONA_FEW_SHOTS=1
+# PERSONA_FEW_SHOT_COUNT=8
+# PERSONA_FEW_SHOT_MAX_CHARS=2500
+# PERSONA_FEW_SHOT_PATH=data/few_shot/persona_examples.jsonl
+
 # Tuya 涂鸦智能家居 API 凭证（可选）
 # 在 https://iot.tuya.com/ 创建项目后获取
 # TUYA_ACCESS_ID=your_access_id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run unit tests
         run: |
-          python3 -m pytest \
-            src/tests/test_reply.py \
-            src/tests/test_debug_logger.py \
-            src/tests/test_layout_profile.py \
-            src/tests/test_message_extractor.py \
-            src/tests/test_session_memory.py \
-            -v
+          python3 -m pytest src/tests -v
 
       - name: Check Python syntax
         run: |
-          python3 -m py_compile $(find src -name "*.py" | head -100)
+          python3 -m compileall -q src

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -73,19 +73,9 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
       - run: |
-          pytest \
-            src/tests/test_reply.py \
-            src/tests/test_debug_logger.py \
-            src/tests/test_layout_profile.py \
-            src/tests/test_message_extractor.py \
-            src/tests/test_session_memory.py \
-            src/tests/test_message_sender.py \
-            src/tests/test_login_recovery.py \
-            src/tests/test_window_capture.py \
-            src/tests/test_window_capture_recovery.py \
-            --cov=src --cov-report=xml --cov-report=term
+          pytest src/tests --cov=src --cov-report=xml --cov-report=term
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This document outlines how to contribute to the project.
 2. **Clone** your fork: `git clone https://github.com/<your-username>/wechat-mac-rpa.git`
 3. **Create a branch**: `git checkout -b feature/your-feature-name`
 4. **Make your changes**
-5. **Run tests**: `python3 -m pytest src/tests/test_*_benchmark.py -v`
+5. **Run tests**: `python3 -m pytest src/tests -v`
 6. **Commit**: Use clear, descriptive commit messages
 7. **Push** and open a Pull Request
 
@@ -35,7 +35,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # Install dependencies
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 
 # Copy config template
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 **中文** | [English](README_EN.md)
 
-让 AI 像人一样"看"着微信界面，自动回复消息。**不碰协议，不读数据库，不注入代码**——微信更新 UI 也不影响运行。
+让 AI 像人一样"看"着微信界面，自动回复消息。默认 OCR / SmartPipeline 模式**不碰协议、不读数据库、不注入代码**；可选 WeFlow 模式会读取用户授权的本地数据库副本，用于初始化历史记忆。
 
-基于**多模态视觉感知**与**LLM Agent**的 macOS 微信自动化框架。不是协议逆向，不是 Hook，不碰微信数据库——我们把微信当作纯黑盒 GUI 应用，用计算机视觉读取界面，用大语言模型理解对话，用系统级自动化操作界面。微信更新 UI 只是换了一套视觉输入，不需要追着协议跑。
+基于**多模态视觉感知**与**LLM Agent**的 macOS 微信自动化框架。默认模式不是协议逆向或 Hook，而是把微信当作纯黑盒 GUI 应用：用计算机视觉读取界面，用大语言模型理解对话，用系统级自动化操作界面。
 
 核心设计：**感知 → 推理 → 行动 → 记忆 → 数据飞轮**，五个子系统构成完整的认知闭环。每一次认知循环的完整链路都被结构化日志逐条记录，形成**可追溯、可回归、可量化**的生产质量资产。
 
@@ -39,8 +39,8 @@
   - 停止服务：`launchctl bootout gui/$(id -u)/com.wechat-mac-rpa.admin`
   - 日志：`tail -f logs/admin-launchd.log logs/admin.log`
   - 前台调试用：`python3 scripts/admin.py`
-- **测试**：`python3 -m pytest src/tests/test_*_benchmark.py -v`
-- **OCR Benchmark**：`python3 src/tests/test_ocr_quality_benchmark.py`
+- **测试**：开发环境先执行 `pip install -r requirements-dev.txt`，再运行 `python3 -m pytest src/tests -v`
+- **OCR Benchmark**：`python3 scripts/benchmark_qwen_vl_ocr.py`
 - **生成报告**：`python3 scripts/generate_ocr_benchmark_report.py`
 
 详细安装与配置指南见 `docs/01-quickstart/AI_QUICKSTART.md`。

--- a/README_EN.md
+++ b/README_EN.md
@@ -95,7 +95,7 @@ Calibrate an LLM-as-Judge with a small amount of human annotation. Once the Judg
 - **Config**: Copy `.env.example` to `.env`, fill in API keys
 - **Permissions**: Enable Screen Recording and Accessibility for your terminal (System Settings → Privacy & Security)
 - **Run**: `python3 run_bot.py`
-- **Test**: `python3 -m pytest src/tests/test_*_benchmark.py -v`
+- **Test**: Install development dependencies with `pip install -r requirements-dev.txt`, then run `python3 -m pytest src/tests -v`
 
 For detailed setup, see `docs/01-quickstart/AI_QUICKSTART.md`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+-r requirements.txt
+
+# 测试依赖
+pytest>=7.0.0
+pytest-asyncio>=1.4.0
+pytest-cov>=7.1.0
+
+# 代码质量 / CI
+ruff>=0.15.20
+mypy>=2.1.0
+bandit>=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.24.3
 sqlalchemy>=2.0.0,<3.0.0
 scikit-learn==1.2.1
 scipy>=1.10.0,<1.16
-Pillow>=12.2.0
+Pillow>=10.0.0,<12.0.0
 requests>=2.34.2
 httpx>=0.28.1
 beautifulsoup4>=4.11.0
@@ -30,13 +30,3 @@ uvicorn>=0.23.0
 # 索引/模型路径见 src/memory/history_search.py 顶部默认值与环境变量。
 tokenizers>=0.23.1
 onnxruntime>=1.16.0
-
-# 测试依赖
-pytest>=7.0.0
-pytest-asyncio>=1.4.0
-pytest-cov>=7.1.0
-
-# 代码质量 / CI
-ruff>=0.15.20
-mypy>=2.1.0
-bandit>=1.8.0

--- a/scripts/build_persona_few_shots.py
+++ b/scripts/build_persona_few_shots.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""从 WeFlow JSON 导出中本地抽取、脱敏并分层选择本人回复样本。"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+# 本地运行时可设置 PERSONA_NAME=王芊 以匹配已有 wiki；代码里不再硬编码真名。
+PERSONA_NAME = os.environ.get("PERSONA_NAME", "本人")
+
+
+SENSITIVE_PATTERNS = [
+    re.compile(r"(?<!\d)1[3-9]\d{9}(?!\d)"),
+    re.compile(r"(?i)https?://|www\."),
+    re.compile(r"(?i)\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b"),
+    re.compile(r"(?i)wxid_[a-z0-9_]+"),
+    re.compile(r"(?<!\d)\d{17}[\dXx](?!\d)"),
+    re.compile(r"(?<!\d)\d{16,19}(?!\d)"),
+    re.compile(r"验证码|密码|身份证|银行卡|收款码|付款码|转账|红包|定位|详细地址"),
+]
+PLACEHOLDER_PATTERNS = [
+    (re.compile(r"(?<!\d)1[3-9]\d{9}(?!\d)"), "[手机号]"),
+    (re.compile(r"(?i)https?://\S+|www\.\S+"), "[链接]"),
+    (re.compile(r"(?i)\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b"), "[邮箱]"),
+    (re.compile(r"(?i)wxid_[a-z0-9_]+"), "[微信账号]"),
+]
+BUSINESS_WORDS = ("店长", "销售", "客服", "设计师", "中介", "物业", "团购", "商家", "客户")
+FAMILY_WORDS = ("家人", "亲属", "父亲", "母亲", "爸爸", "妈妈", "夫妻", "老公", "老婆", "伴侣", "兄弟姐妹")
+COLLEAGUE_WORDS = ("同事", "同学", "校友", "合作", "工作关系", "前同事")
+FRIEND_WORDS = ("好友", "朋友", "关系很好", "熟识", "发小", "闺蜜")
+HUMOR_PATTERNS = (
+    re.compile(r"哈哈|笑死|绷不住|离谱|救命|牛的|绝了|难民|韭菜|躺平|破防|认亲"),
+    re.compile(r"[😂🤣😅🤡🙃😏]|\[(?:捂脸|旺柴|破涕为笑|偷笑|呲牙)\]"),
+    re.compile(r"哪有|怕不是|属实|看来.*要|估计.*正|就剩|给.*加分"),
+)
+
+
+@dataclass
+class Candidate:
+    relation: str
+    chat_id: str
+    context: list[str]
+    replies: list[str]
+    score: float
+    timestamp: int
+    priority: bool = False
+
+
+def _stable_id(value: str, prefix: str = "chat") -> str:
+    return f"{prefix}_{hashlib.sha256(value.encode('utf-8')).hexdigest()[:10]}"
+
+
+def _is_text(message: dict) -> bool:
+    return message.get("localType") == 1 and bool(str(message.get("content") or "").strip())
+
+
+def _safe_text(text: str) -> bool:
+    text = text.strip()
+    if not 1 <= len(text) <= 160 or text.startswith("<"):
+        return False
+    return not any(pattern.search(text) for pattern in SENSITIVE_PATTERNS)
+
+
+def _sanitize(text: str, names: Iterable[str]) -> str:
+    result = text.strip()
+    for pattern, replacement in PLACEHOLDER_PATTERNS:
+        result = pattern.sub(replacement, result)
+    for name in sorted({n.strip() for n in names if 2 <= len(n.strip()) <= 30}, key=len, reverse=True):
+        result = result.replace(name, "[联系人]")
+    return re.sub(r"\s+", " ", result).strip()
+
+
+def _wiki_relation(export_path: Path, wiki_dir: Path) -> str:
+    stem = export_path.stem
+    if stem.startswith("群聊_"):
+        return "group"
+    display_name = re.sub(r"^(私聊_|曾经的好友_)", "", stem)
+    safe_display_name = re.sub(r"[^\w\u4e00-\u9fff-]+", "_", display_name)
+    candidates = [
+        wiki_dir / f"{display_name}.md",
+        wiki_dir / f"{safe_display_name}.md",
+    ]
+    text = ""
+    for path in candidates:
+        if path.exists():
+            text = path.read_text(encoding="utf-8", errors="ignore")[:5000]
+            break
+    persona_pattern = re.escape(PERSONA_NAME)
+    match = re.search(
+        r"(?ms)^##\s*与\s*(?:Bot|" + persona_pattern + r")\s*的关系\s*$\n(.*?)(?=^##\s|\Z)",
+        text,
+    )
+    relation_text = match.group(1) if match else ""
+    if any(word in relation_text for word in FAMILY_WORDS):
+        return "family"
+    if any(word in relation_text for word in COLLEAGUE_WORDS):
+        return "colleague"
+    if any(word in relation_text for word in FRIEND_WORDS):
+        return "friend"
+    if any(word in f"{display_name}\n{relation_text}" for word in BUSINESS_WORDS):
+        return "service"
+    return "acquaintance"
+
+
+def _score(context: list[str], replies: list[str]) -> float:
+    reply = "".join(replies)
+    score = 10.0 - abs(len(reply) - 14) * 0.08
+    score += min(len(context), 3) * 0.5
+    score += 1.0 if re.search(r"[哈嗯哦诶吧呀呢啊嘛～~]|[？?!！]", reply) else 0.0
+    score -= max(0, len(reply) - 80) * 0.08
+    score -= 2.0 if re.search(r"首先|其次|综上|总之|建议您|以下是", reply) else 0.0
+    score += sum(1.8 for pattern in HUMOR_PATTERNS if pattern.search(reply))
+    return score
+
+
+def extract_candidates(export_dir: Path, wiki_dir: Path) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+    for path in sorted(export_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        messages = payload.get("messages", [])
+        relation = _wiki_relation(path, wiki_dir)
+        chat_id = _stable_id(path.stem)
+        session_name = str(payload.get("session", {}).get("displayName") or "")
+        all_names = {session_name, re.sub(r"^(私聊_|群聊_|曾经的好友_)", "", path.stem)}
+        all_names.update(str(m.get("senderDisplayName") or "") for m in messages)
+        i = 0
+        while i < len(messages):
+            if not _is_text(messages[i]) or messages[i].get("isSend"):
+                i += 1
+                continue
+            incoming: list[dict] = []
+            while i < len(messages) and _is_text(messages[i]) and not messages[i].get("isSend") and len(incoming) < 5:
+                incoming.append(messages[i])
+                i += 1
+            outgoing: list[dict] = []
+            while i < len(messages) and _is_text(messages[i]) and messages[i].get("isSend") and len(outgoing) < 3:
+                outgoing.append(messages[i])
+                i += 1
+            if not incoming or not outgoing:
+                continue
+            if relation == "group":
+                senders = {m.get("senderUsername") or m.get("senderDisplayName") for m in incoming}
+                if len(senders) != 1:
+                    continue
+            raw_context = [str(m.get("content") or "") for m in incoming]
+            raw_replies = [str(m.get("content") or "") for m in outgoing]
+            if not all(_safe_text(t) for t in raw_context + raw_replies):
+                continue
+            context = [_sanitize(t, all_names) for t in raw_context]
+            replies = [_sanitize(t, all_names) for t in raw_replies]
+            if not all(context + replies):
+                continue
+            fingerprint = re.sub(r"\W+", "", "|".join(context + replies)).lower()
+            if len(fingerprint) < 3 or fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            candidates.append(Candidate(
+                relation=relation,
+                chat_id=chat_id,
+                context=context,
+                replies=replies,
+                score=_score(context, replies),
+                timestamp=int(outgoing[0].get("createTime") or 0),
+            ))
+    return candidates
+
+
+def extract_chat_backup(path: Path) -> list[Candidate]:
+    """抽取 GlobalStore 聊天备份；仅 sender_type=self 视为本人真实发言。"""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    messages = payload.get("messages", [])
+    chat_name = str(payload.get("chat_name") or path.stem)
+    chat_id = _stable_id(chat_name)
+    names = {chat_name}
+    names.update(str(m.get("sender") or "") for m in messages if m.get("sender_type") != "self")
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+    for index, message in enumerate(messages):
+        if message.get("sender_type") != "self" or message.get("message_type") != "text":
+            continue
+        reply = str(message.get("text") or "").strip()
+        if not _safe_text(reply):
+            continue
+        incoming: list[str] = []
+        cursor = index - 1
+        while cursor >= 0 and len(incoming) < 5:
+            previous = messages[cursor]
+            if previous.get("sender_type") == "self":
+                break
+            text = str(previous.get("text") or "").strip()
+            if previous.get("message_type") == "text" and _safe_text(text):
+                incoming.append(text)
+            cursor -= 1
+        if not incoming:
+            continue
+        context = [_sanitize(text, names) for text in reversed(incoming)]
+        replies = [_sanitize(reply, names)]
+        fingerprint = re.sub(r"\W+", "", "|".join(context + replies)).lower()
+        if len(fingerprint) < 3 or fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        candidates.append(Candidate(
+            relation="group",
+            chat_id=chat_id,
+            context=context,
+            replies=replies,
+            score=_score(context, replies) + 6.0,
+            timestamp=int(message.get("createTime") or 0),
+            priority=True,
+        ))
+    return candidates
+
+
+def select_balanced(candidates: list[Candidate], limit: int, group_target: int = 0) -> list[Candidate]:
+    by_relation: dict[str, list[Candidate]] = defaultdict(list)
+    for candidate in candidates:
+        by_relation[candidate.relation].append(candidate)
+    for rows in by_relation.values():
+        rows.sort(key=lambda c: (-c.score, -c.timestamp, c.chat_id))
+    selected: list[Candidate] = []
+    per_chat: Counter[str] = Counter()
+    if group_target:
+        group_rows = by_relation.get("group", [])
+        group_rows.sort(key=lambda c: (not c.priority, -c.score, -c.timestamp, c.chat_id))
+        while group_rows and len(selected) < min(group_target, limit):
+            candidate = group_rows.pop(0)
+            max_per_chat = 15 if candidate.priority else 3
+            if per_chat[candidate.chat_id] >= max_per_chat:
+                continue
+            selected.append(candidate)
+            per_chat[candidate.chat_id] += 1
+    relations = ["family", "friend", "colleague", "acquaintance", "service"]
+    if not group_target:
+        relations.append("group")
+    while len(selected) < limit:
+        progressed = False
+        for relation in relations:
+            rows = by_relation.get(relation, [])
+            while rows and per_chat[rows[0].chat_id] >= 3:
+                rows.pop(0)
+            if rows:
+                candidate = rows.pop(0)
+                selected.append(candidate)
+                per_chat[candidate.chat_id] += 1
+                progressed = True
+                if len(selected) >= limit:
+                    break
+        if not progressed:
+            break
+    return selected
+
+
+def write_outputs(selected: list[Candidate], output_dir: Path, candidate_count: int) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = output_dir / "persona_examples.jsonl"
+    md_path = output_dir / "persona_examples.md"
+    report_path = output_dir / "report.json"
+    rows = []
+    for index, candidate in enumerate(selected, 1):
+        rows.append({
+            "id": f"example_{index:03d}",
+            "relationship": candidate.relation,
+            "chat_id": candidate.chat_id,
+            "context": candidate.context,
+            "reply": candidate.replies,
+        })
+    jsonl_path.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows), encoding="utf-8")
+    md_lines = ["# 本人真实回复 Few-shot（已脱敏）", "", "> 纯本地生成；请人工复核后再接入生产 prompt。", ""]
+    for row in rows:
+        md_lines.extend([
+            f"## {row['id']} · {row['relationship']}", "",
+            *[f"- 对方：{text}" for text in row["context"]],
+            *[f"- 本人：{text}" for text in row["reply"]], "",
+        ])
+    md_path.write_text("\n".join(md_lines), encoding="utf-8")
+    report = {
+        "candidate_count": candidate_count,
+        "selected_count": len(rows),
+        "relationship_counts": dict(sorted(Counter(row["relationship"] for row in rows).items())),
+        "unique_chat_count": len({row["chat_id"] for row in rows}),
+        "sensitive_pattern_scan_passed": not any(
+            pattern.search(text)
+            for row in rows
+            for text in [*row["context"], *row["reply"]]
+            for pattern in SENSITIVE_PATTERNS
+        ),
+        "external_model_used": False,
+    }
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=Path("data/exports/b"))
+    parser.add_argument("--wiki-dir", type=Path, default=Path("data/memory/wiki/users"))
+    parser.add_argument("--output", type=Path, default=Path("data/few_shot"))
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--group-target", type=int, default=0)
+    parser.add_argument("--chat-backup", type=Path, action="append", default=[])
+    args = parser.parse_args()
+    candidates = extract_candidates(args.input, args.wiki_dir)
+    for backup in args.chat_backup:
+        candidates.extend(extract_chat_backup(backup))
+    selected = select_balanced(candidates, args.limit, group_target=args.group_target)
+    if len(selected) < args.limit:
+        raise SystemExit(f"候选不足：需要 {args.limit}，实际 {len(selected)}")
+    write_outputs(selected, args.output, len(candidates))
+    print(json.dumps({"candidates": len(candidates), "selected": len(selected)}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bot/wechat_bot.py
+++ b/src/bot/wechat_bot.py
@@ -672,6 +672,7 @@ class WeChatBot:
         self.running = True
         self._interval = interval
         while self.running:
+            tick_started = time.monotonic()
             try:
                 self.tick()
             except Exception as e:
@@ -680,7 +681,7 @@ class WeChatBot:
             if self._tick_id > 0 and self._tick_id % 60 == 0:
                 from src.utils.qwen_client import QwenClient
                 QwenClient.log_token_stats(self.logger.runtime_logger)
-            time.sleep(interval)
+            time.sleep(max(0.0, interval - (time.monotonic() - tick_started)))
 
     _SERVICE_ACCOUNT_NAMES = {"服务号", "订阅号", "公众号"}
 

--- a/src/memory/engine.py
+++ b/src/memory/engine.py
@@ -221,6 +221,7 @@ class MemoryEngine:
         # 异步更新队列
         self._update_queue: List[dict] = []
         self._queue_lock = threading.Lock()
+        self._queue_condition = threading.Condition(self._queue_lock)
         self._aliases_lock = threading.Lock()
         self._worker_thread: Optional[threading.Thread] = None
         self._shutdown = False
@@ -372,7 +373,7 @@ class MemoryEngine:
             _logger.warning(f"非法用户名，跳过 wiki 更新: {user_name}")
             return
         resolved = self._resolve_alias(user_name)
-        with self._queue_lock:
+        with self._queue_condition:
             self._update_queue.append({
                 "type": "user",
                 "user_name": resolved,  # 用主用户名更新
@@ -381,6 +382,7 @@ class MemoryEngine:
                 "bot_replies": bot_replies,
                 "timestamp": time.time(),
             })
+            self._queue_condition.notify()
 
     def update_group_wiki(self, group_name: str, chat_name: str,
                           messages: List, bot_replies: List[str]) -> None:
@@ -394,7 +396,7 @@ class MemoryEngine:
         if any(p.search(group_name) for p in _AD_GROUP_PATTERNS):
             _logger.debug("广告群跳过 wiki 生成: %s", group_name)
             return
-        with self._queue_lock:
+        with self._queue_condition:
             self._update_queue.append({
                 "type": "group",
                 "group_name": group_name,
@@ -403,12 +405,15 @@ class MemoryEngine:
                 "bot_replies": bot_replies,
                 "timestamp": time.time(),
             })
+            self._queue_condition.notify()
 
     def shutdown(self) -> None:
         """关闭 worker 线程，等待队列清空。"""
-        self._shutdown = True
+        with self._queue_condition:
+            self._shutdown = True
+            self._queue_condition.notify_all()
         if self._worker_thread and self._worker_thread.is_alive():
-            self._worker_thread.join(timeout=10)
+            self._worker_thread.join()
 
     # ── 内部方法 ──
 
@@ -1359,19 +1364,26 @@ class MemoryEngine:
     def _start_worker(self) -> None:
         """启动后台 worker 线程，定期处理更新队列。"""
         def _worker():
-            while not self._shutdown:
-                time.sleep(5)
+            while True:
                 batch = []
-                with self._queue_lock:
-                    if len(self._update_queue) >= 3:
+                with self._queue_condition:
+                    if self._shutdown:
+                        batch = self._update_queue[:]
+                        self._update_queue.clear()
+                        if not batch:
+                            return
+                    elif len(self._update_queue) >= 3:
                         batch = self._update_queue[:3]
-                        self._update_queue = self._update_queue[3:]
+                        del self._update_queue[:3]
                     elif self._update_queue:
                         now = time.time()
                         cutoff = [i for i, t in enumerate(self._update_queue) if now - t["timestamp"] > 300]
                         if cutoff:
                             batch = self._update_queue[:cutoff[-1] + 1]
-                            self._update_queue = self._update_queue[len(batch):]
+                            del self._update_queue[:len(batch)]
+                    if not batch:
+                        self._queue_condition.wait(timeout=5)
+                        continue
                 for task in batch:
                     try:
                         self._do_update(task)

--- a/src/reply/few_shot.py
+++ b/src/reply/few_shot.py
@@ -1,0 +1,86 @@
+"""生产回复使用的本地 persona few-shot 召回。"""
+
+import hashlib
+import json
+import logging
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+_logger = logging.getLogger("src.reply.few_shot")
+
+
+def _chat_id(chat_name: str) -> str:
+    return f"chat_{hashlib.sha256(chat_name.encode('utf-8')).hexdigest()[:10]}"
+
+
+def _terms(text: str) -> list[str]:
+    normalized = re.sub(r"\s+", "", text.lower())
+    chars = [char for char in normalized if char.isalnum() or "\u4e00" <= char <= "\u9fff"]
+    singles = chars if len(chars) <= 12 else chars[:12]
+    return singles + ["".join(chars[i:i + 2]) for i in range(max(0, len(chars) - 1))]
+
+
+class PersonaFewShotRetriever:
+    def __init__(self, path: Path):
+        self.path = path
+        self._mtime_ns = -1
+        self._rows: list[dict[str, Any]] = []
+
+    def _load(self) -> list[dict[str, Any]]:
+        try:
+            mtime_ns = self.path.stat().st_mtime_ns
+        except OSError:
+            return []
+        if mtime_ns == self._mtime_ns:
+            return self._rows
+        rows = []
+        try:
+            for line in self.path.read_text(encoding="utf-8").splitlines():
+                row = json.loads(line)
+                if row.get("id") and isinstance(row.get("context"), list) and isinstance(row.get("reply"), list):
+                    rows.append(row)
+        except (OSError, json.JSONDecodeError) as exc:
+            _logger.warning("persona few-shot 加载失败: %s", exc)
+            return []
+        self._mtime_ns = mtime_ns
+        self._rows = rows
+        return rows
+
+    def retrieve(self, query: str, chat_name: str, is_group: bool, limit: int = 8) -> list[dict[str, Any]]:
+        query_terms = Counter(_terms(query))
+        current_chat_id = _chat_id(chat_name) if chat_name else ""
+        scored = []
+        for row in self._load():
+            if is_group != (row.get("relationship") == "group"):
+                continue
+            sample_text = " ".join(row["context"] + row["reply"])
+            sample_terms = Counter(_terms(sample_text))
+            overlap = sum(min(count, sample_terms.get(term, 0)) for term, count in query_terms.items())
+            length_similarity = 1.0 / (1.0 + abs(len(query) - len(sample_text)) / 20.0)
+            same_chat = bool(current_chat_id and row.get("chat_id") == current_chat_id)
+            scored.append((same_chat, overlap * 2.0 + length_similarity, row["id"], row))
+        scored.sort(key=lambda item: (not item[0], -item[1], item[2]))
+        return [row for _, _, _, row in scored[:max(0, limit)]]
+
+    @staticmethod
+    def render(rows: list[dict[str, Any]], max_chars: int = 2500) -> tuple[str, list[str]]:
+        if not rows:
+            return "", []
+        parts = [
+            "【本人真实聊天风格示例】",
+            "以下内容只用于模仿表达长度、语气、接梗方式和聊天节奏。",
+            "示例中的人物、事件和事实都不是当前对话事实，禁止照搬或引用。",
+        ]
+        ids = []
+        for row in rows:
+            block = [f"示例 {row['id']}："]
+            block.extend(f"对方：{text}" for text in row["context"])
+            block.extend(f"本人：{text}" for text in row["reply"])
+            if len("\n".join(parts + block)) > max_chars:
+                break
+            parts.extend(block)
+            ids.append(row["id"])
+        return ("\n".join(parts), ids) if ids else ("", [])

--- a/src/reply/generator.py
+++ b/src/reply/generator.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from src.models.base import MEDIA_MESSAGE_TYPES, ChatMessage, SenderType
+from src.reply.few_shot import PersonaFewShotRetriever
 from src.reply.session_memory import SessionMemory, _extract_query_key
 from src.tools import get_registry
 
@@ -47,6 +48,13 @@ _QUESTION_WORDS = {"吗", "呢", "谁", "什么", "哪里", "哪儿", "怎么", 
 
 # ReAct 工具调用上限
 MAX_TOOL_CALLS = 10
+
+
+def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
+    try:
+        return max(minimum, min(maximum, int(os.environ.get(name, str(default)))))
+    except ValueError:
+        return default
 
 # Skill 路由优先级（数字越小优先级越高）
 _SKILL_PRIORITY = [
@@ -102,6 +110,15 @@ class ReplyGenerator:
         if enable_mode_detection is None:
             enable_mode_detection = os.environ.get("WECHAT_MODE_DETECTION", "0").lower() in ("1", "true", "yes", "on")
         self.enable_mode_detection = enable_mode_detection
+        project_root = Path(__file__).parent.parent.parent
+        few_shot_path = Path(os.environ.get(
+            "PERSONA_FEW_SHOT_PATH",
+            str(project_root / "data" / "few_shot" / "persona_examples.jsonl"),
+        ))
+        self.enable_persona_few_shots = os.environ.get("ENABLE_PERSONA_FEW_SHOTS", "1").lower() in ("1", "true", "yes", "on")
+        self.persona_few_shot_count = _env_int("PERSONA_FEW_SHOT_COUNT", 8, 0, 12)
+        self.persona_few_shot_max_chars = _env_int("PERSONA_FEW_SHOT_MAX_CHARS", 2500, 500, 5000)
+        self.persona_few_shot_retriever = PersonaFewShotRetriever(few_shot_path)
         _logger.info(f"[ReplyGenerator] init: llm_client={type(llm_client).__name__ if llm_client else None}")
         # 最后一次调用的 prompt/response（供 debug 使用）
         self.last_system_prompt: str = ""
@@ -116,6 +133,8 @@ class ReplyGenerator:
         # Skill 加载状态（供 debug 使用）
         self.last_loaded_skills: List[str] = []
         self.last_skill_injected_content: str = ""
+        self.last_few_shot_ids: List[str] = []
+        self.last_few_shot_content: str = ""
         # 当前使用的模型名（供 debug 使用）
         self.last_active_llm: str = ""
         # 传给 Judge 的完整 LLM 上下文
@@ -625,6 +644,8 @@ class ReplyGenerator:
         self.last_generation_trace = []
         self.last_loaded_skills = []
         self.last_skill_injected_content = ""
+        self.last_few_shot_ids = []
+        self.last_few_shot_content = ""
         self.last_llm_messages = []
         self.last_self_refine_applied = False
         self.last_feedback_decision = ""
@@ -705,6 +726,29 @@ class ReplyGenerator:
                 user_prompt += "\n\n" + "\n\n".join(skill_parts)
         self.last_skill_injected_content = "\n\n".join(skill_parts) if skill_parts else ""
 
+        if self.enable_persona_few_shots and self.persona_few_shot_count:
+            few_shot_rows = self.persona_few_shot_retriever.retrieve(
+                query=route_text,
+                chat_name=chat_name,
+                is_group=is_group,
+                limit=self.persona_few_shot_count,
+            )
+            few_shot_content, few_shot_ids = self.persona_few_shot_retriever.render(
+                few_shot_rows,
+                max_chars=self.persona_few_shot_max_chars,
+            )
+            if few_shot_content:
+                user_prompt += "\n\n" + few_shot_content
+                self.last_few_shot_content = few_shot_content
+                self.last_few_shot_ids = few_shot_ids
+                self.last_generation_trace.append({
+                    "round": 0,
+                    "type": "persona_few_shot",
+                    "timestamp": time.time(),
+                    "ids": few_shot_ids,
+                })
+                _logger.info("[PersonaFewShot] chat=%s ids=%s", chat_name, few_shot_ids)
+
         self.last_system_prompt = system_prompt
         self.last_tools_context = tools_context
 
@@ -772,13 +816,6 @@ class ReplyGenerator:
                 replies = current_replies
                 final_messages = current_messages
 
-                # Iterate 后如果本地硬性规则已通过，按 pass 记录，避免 display 误导
-                if self._local_rule_check(replies, self.last_loaded_skills):
-                    pass  # 仍有 issue，保留 fail 记录
-                else:
-                    decision = "pass"
-                    self.last_feedback_decision = decision
-                    self.last_feedback_issues = []
             elif decision == "error":
                 fallback_issues = self._local_rule_check(replies, self.last_loaded_skills)
                 if fallback_issues:

--- a/src/tests/test_bot.py
+++ b/src/tests/test_bot.py
@@ -137,3 +137,18 @@ class TestWeChatBot:
 
         assert result.success is True
         bot.sender.send.assert_called_once_with("hello", chat_name="测试群")
+
+    def test_run_auto_keeps_fixed_interval(self, monkeypatch):
+        """tick 耗时应从轮询间隔中扣除，避免周期持续漂移。"""
+        bot = WeChatBot.__new__(WeChatBot)
+        bot._tick_id = 1
+        bot.logger = Mock()
+        bot.tick = Mock(side_effect=lambda: setattr(bot, "running", False))
+        monotonic = Mock(side_effect=[10.0, 12.0])
+        sleep = Mock()
+        monkeypatch.setattr("src.bot.wechat_bot.time.monotonic", monotonic)
+        monkeypatch.setattr("src.bot.wechat_bot.time.sleep", sleep)
+
+        bot.run_auto(interval=5.0)
+
+        sleep.assert_called_once_with(3.0)

--- a/src/tests/test_build_persona_few_shots.py
+++ b/src/tests/test_build_persona_few_shots.py
@@ -1,0 +1,97 @@
+import json
+
+from scripts.build_persona_few_shots import extract_candidates, extract_chat_backup, select_balanced, write_outputs
+
+
+def _message(text, sent, timestamp, sender="contact"):
+    return {
+        "content": text,
+        "createTime": timestamp,
+        "isSend": sent,
+        "localType": 1,
+        "senderDisplayName": sender,
+        "senderUsername": sender,
+    }
+
+
+def test_extracts_and_anonymizes_conversation(tmp_path):
+    export_dir = tmp_path / "exports"
+    wiki_dir = tmp_path / "wiki"
+    export_dir.mkdir()
+    wiki_dir.mkdir()
+    payload = {
+        "session": {"displayName": "张三"},
+        "messages": [
+            _message("张三你晚上来吗", False, 1, "张三"),
+            _message("来呀，晚点到", True, 2, "本人"),
+        ],
+    }
+    (export_dir / "私聊_张三.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    rows = extract_candidates(export_dir, wiki_dir)
+
+    assert len(rows) == 1
+    assert rows[0].context == ["[联系人]你晚上来吗"]
+    assert rows[0].replies == ["来呀，晚点到"]
+    assert "张三" not in rows[0].chat_id
+
+
+def test_rejects_sensitive_conversation(tmp_path):
+    export_dir = tmp_path / "exports"
+    wiki_dir = tmp_path / "wiki"
+    export_dir.mkdir()
+    wiki_dir.mkdir()
+    payload = {
+        "session": {},
+        "messages": [
+            _message("验证码是123456", False, 1),
+            _message("收到", True, 2),
+        ],
+    }
+    (export_dir / "私聊_联系人.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    assert extract_candidates(export_dir, wiki_dir) == []
+
+
+def test_balanced_selection_and_outputs(tmp_path):
+    export_dir = tmp_path / "exports"
+    wiki_dir = tmp_path / "wiki"
+    export_dir.mkdir()
+    wiki_dir.mkdir()
+    for index in range(4):
+        payload = {
+            "session": {},
+            "messages": [
+                _message(f"问题{index}", False, index * 2 + 1),
+                _message(f"回答{index}呀", True, index * 2 + 2),
+            ],
+        }
+        (export_dir / f"私聊_联系人{index}.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    candidates = extract_candidates(export_dir, wiki_dir)
+    selected = select_balanced(candidates, 3)
+    write_outputs(selected, tmp_path / "out", len(candidates))
+
+    lines = (tmp_path / "out" / "persona_examples.jsonl").read_text(encoding="utf-8").splitlines()
+    report = json.loads((tmp_path / "out" / "report.json").read_text(encoding="utf-8"))
+    assert len(lines) == 3
+    assert report["selected_count"] == 3
+    assert report["external_model_used"] is False
+
+
+def test_extracts_self_from_chat_backup(tmp_path):
+    path = tmp_path / "幽默群.json"
+    payload = {
+        "chat_name": "幽默群",
+        "messages": [
+            {**_message("今天又跌了", False, 1, "群友"), "sender_type": "other", "message_type": "text", "text": "今天又跌了"},
+            {**_message("韭菜申请躺平😂", True, 2, "自己"), "sender_type": "self", "message_type": "text", "text": "韭菜申请躺平😂"},
+        ],
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    rows = extract_chat_backup(path)
+
+    assert len(rows) == 1
+    assert rows[0].relation == "group"
+    assert rows[0].priority is True
+    assert rows[0].replies == ["韭菜申请躺平😂"]

--- a/src/tests/test_judge_quality_benchmark_v2.py
+++ b/src/tests/test_judge_quality_benchmark_v2.py
@@ -86,7 +86,12 @@ class JudgeBenchmarkResult:
 
 def _load_gt_cases() -> List[JudgeBenchmarkCase]:
     """从 tick_log 读取所有人工标注的 tick，构建 benchmark cases。"""
-    conn = sqlite3.connect(str(DB_PATH))
+    if not DB_PATH.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(DB_PATH))
+    except sqlite3.OperationalError:
+        return []
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         "SELECT * FROM tick_log WHERE human_is_badcase IS NOT NULL ORDER BY id"

--- a/src/tests/test_memory_search.py
+++ b/src/tests/test_memory_search.py
@@ -369,6 +369,21 @@ class TestLintMemory:
         assert engine._update_queue == []
 
 
+def test_shutdown_drains_pending_updates(tmp_path):
+    """退出时即使队列不足批量阈值，也必须处理完已有任务。"""
+    engine = MemoryEngine(llm_client=object())
+    engine.wiki_dir = tmp_path
+    processed = []
+    engine._do_update = processed.append
+
+    engine.update_user_wiki("测试用户", "测试会话", [], [])
+    engine.shutdown()
+
+    assert len(processed) == 1
+    assert processed[0]["user_name"] == "测试用户"
+    assert engine._update_queue == []
+
+
 class TestLLMRerank:
     """LLM rerank：BM25 候选用 LLM 按语义相关性重排 + 降级。"""
 

--- a/src/tests/test_persona_few_shot.py
+++ b/src/tests/test_persona_few_shot.py
@@ -1,0 +1,83 @@
+import hashlib
+import json
+
+from src.models.base import ChatMessage, SenderType
+from src.reply.few_shot import PersonaFewShotRetriever
+from src.reply.generator import ReplyGenerator
+
+
+def _write_rows(path, rows):
+    path.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows), encoding="utf-8")
+
+
+def test_group_retrieval_prefers_same_chat(tmp_path):
+    path = tmp_path / "examples.jsonl"
+    chat_name = "柚子群2"
+    same_chat_id = "chat_" + hashlib.sha256(chat_name.encode()).hexdigest()[:10]
+    _write_rows(path, [
+        {"id": "other", "relationship": "group", "chat_id": "chat_other", "context": ["股票跌了"], "reply": ["躺平"]},
+        {"id": "same", "relationship": "group", "chat_id": same_chat_id, "context": ["晚上吃啥"], "reply": ["喝西北风"]},
+        {"id": "private", "relationship": "friend", "chat_id": "chat_private", "context": ["股票跌了"], "reply": ["知道了"]},
+    ])
+
+    rows = PersonaFewShotRetriever(path).retrieve("股票跌了", chat_name, is_group=True, limit=2)
+
+    assert [row["id"] for row in rows] == ["same", "other"]
+
+
+def test_private_retrieval_excludes_group_examples(tmp_path):
+    path = tmp_path / "examples.jsonl"
+    _write_rows(path, [
+        {"id": "group", "relationship": "group", "chat_id": "g", "context": ["在吗"], "reply": ["咋"]},
+        {"id": "friend", "relationship": "friend", "chat_id": "f", "context": ["在吗"], "reply": ["咋啦"]},
+    ])
+
+    rows = PersonaFewShotRetriever(path).retrieve("在吗", "朋友", is_group=False, limit=8)
+
+    assert [row["id"] for row in rows] == ["friend"]
+
+
+def test_render_has_fact_isolation_and_budget(tmp_path):
+    rows = [
+        {"id": "one", "context": ["在吗"], "reply": ["咋啦"]},
+        {"id": "two", "context": ["x" * 100], "reply": ["y" * 100]},
+    ]
+
+    content, ids = PersonaFewShotRetriever.render(rows, max_chars=170)
+
+    assert ids == ["one"]
+    assert "不是当前对话事实" in content
+    assert "本人：咋啦" in content
+
+
+def test_missing_file_degrades_to_empty(tmp_path):
+    retriever = PersonaFewShotRetriever(tmp_path / "missing.jsonl")
+
+    assert retriever.retrieve("你好", "朋友", is_group=False) == []
+
+
+def test_generator_injects_examples_and_records_ids(tmp_path, monkeypatch):
+    path = tmp_path / "examples.jsonl"
+    _write_rows(path, [
+        {"id": "style_one", "relationship": "friend", "chat_id": "f", "context": ["在吗"], "reply": ["咋啦"]},
+    ])
+    monkeypatch.setenv("PERSONA_FEW_SHOT_PATH", str(path))
+    monkeypatch.setenv("ENABLE_PERSONA_FEW_SHOTS", "1")
+
+    class LLM:
+        def __init__(self):
+            self.responses = ['{"skills": []}', '{"replies": ["在的"]}']
+
+        def chat(self, messages, tools=None, **kwargs):
+            return self.responses.pop(0)
+
+    message = ChatMessage(text="在吗", sender="朋友", sender_type=SenderType.OTHER, chat_name="朋友")
+    generator = ReplyGenerator(llm_client=LLM())
+    generator.enable_self_refine = False
+
+    replies = generator.generate([message], [message], is_group=False)
+
+    assert replies == ["在的"]
+    assert generator.last_few_shot_ids == ["style_one"]
+    assert "本人真实聊天风格示例" in generator.last_user_prompt
+    assert any(item.get("type") == "persona_few_shot" for item in generator.last_generation_trace)

--- a/src/tests/test_reply_quality_benchmark_v2.py
+++ b/src/tests/test_reply_quality_benchmark_v2.py
@@ -49,7 +49,12 @@ class ReplyBenchmarkCase:
 
 def load_cases() -> List[ReplyBenchmarkCase]:
     """从 tick_log 读取所有人工标注的 tick。"""
-    conn = sqlite3.connect(str(DB_PATH))
+    if not DB_PATH.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(DB_PATH))
+    except sqlite3.OperationalError:
+        return []
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         "SELECT * FROM tick_log WHERE human_is_badcase IS NOT NULL ORDER BY id"


### PR DESCRIPTION
本次 PR 合并近期工作区改动，并补充修复：\n\n新增：\n- src/reply/few_shot.py：本地 persona few-shot 召回与 prompt 渲染\n- scripts/build_persona_few_shots.py：从 WeFlow 导出 / 聊天备份抽取、脱敏、分层生成 few-shot 样本\n- src/tests/test_persona_few_shot.py、test_build_persona_few_shots.py：对应测试\n- .env.example：增加 ENABLE_PERSONA_FEW_SHOTS 等配置\n\n修复：\n- requirements.txt 与 requirements-dev.txt 拆分；CI/Quality workflow 改安装 requirements-dev.txt\n- src/bot/wechat_bot.py：tick 周期扣除执行耗时，防止漂移\n- src/memory/engine.py：后台 worker 改用 Condition，shutdown() 会排空队列\n- scripts/build_persona_few_shots.py：修复 Python 3.10 f-string 反斜杠 SyntaxError；移除硬编码真名；修复 chat backup 时间戳字段名\n\n验证：\n- pytest src/tests：326 passed, 13 skipped\n- ruff critical / mypy / bandit 均通过