### PR TITLE
chore: switch default Dashscope endpoint to dashscope.aliyuncs.com

### DIFF
--- a/scripts/benchmark_qwen_vl_ocr.py
+++ b/scripts/benchmark_qwen_vl_ocr.py
@@ -187,7 +187,7 @@ class QwenVLOCRClient:
             )
         self.client = OpenAI(
             api_key=self.api_key,
-            base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         )
         self.model = model
         self.extra_body = {}

--- a/scripts/bulk_import_fast.py
+++ b/scripts/bulk_import_fast.py
@@ -15,7 +15,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
-client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
+client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"))
 
 store = GlobalStore()
 target_name = next((n for n in store.chats if "共同富裕" in n), None)

--- a/scripts/bulk_import_optimal.py
+++ b/scripts/bulk_import_optimal.py
@@ -15,7 +15,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
-client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
+client = OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"))
 
 store = GlobalStore()
 target_name = next((n for n in store.chats if "共同富裕" in n), None)

--- a/scripts/bulk_import_with_mem0.py
+++ b/scripts/bulk_import_with_mem0.py
@@ -25,7 +25,7 @@ config = {
         "config": {
             "model": "deepseek-v4-flash",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "embedder": {
@@ -33,7 +33,7 @@ config = {
         "config": {
             "model": "text-embedding-v3",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "vector_store": {
@@ -82,7 +82,7 @@ prompt = f"""从以下微信聊天记录中提取所有关键事实。
 
 print("\nLLM 提取事实...")
 import openai
-client = openai.OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
+client = openai.OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"))
 resp = client.chat.completions.create(
     model="deepseek-v4-flash",
     messages=[{"role": "user", "content": prompt}],

--- a/scripts/test_custom_prompt.py
+++ b/scripts/test_custom_prompt.py
@@ -21,7 +21,7 @@ config = {
         "config": {
             "model": "deepseek-v4-flash",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "embedder": {
@@ -29,7 +29,7 @@ config = {
         "config": {
             "model": "text-embedding-v3",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "vector_store": {

--- a/scripts/test_mem0.py
+++ b/scripts/test_mem0.py
@@ -16,7 +16,7 @@ config = {
         "config": {
             "model": "deepseek-v4-flash",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "embedder": {
@@ -24,7 +24,7 @@ config = {
         "config": {
             "model": "text-embedding-v3",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "vector_store": {

--- a/scripts/test_mem0_one_group.py
+++ b/scripts/test_mem0_one_group.py
@@ -25,7 +25,7 @@ config = {
         "config": {
             "model": "deepseek-v4-flash",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "embedder": {
@@ -33,7 +33,7 @@ config = {
         "config": {
             "model": "text-embedding-v3",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "vector_store": {

--- a/scripts/test_skip_phase1.py
+++ b/scripts/test_skip_phase1.py
@@ -24,7 +24,7 @@ config = {
         "config": {
             "model": "deepseek-v4-flash",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "embedder": {
@@ -32,7 +32,7 @@ config = {
         "config": {
             "model": "text-embedding-v3",
             "api_key": DASHSCOPE_API_KEY,
-            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            "openai_base_url": os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         }
     },
     "vector_store": {
@@ -98,7 +98,7 @@ print(f"\n... (共 {len(user_prompt)} 字符，已截断)")
 # 3. 调 LLM 提取事实
 print("\n调 LLM 提取事实...")
 import openai
-client = openai.OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"))
+client = openai.OpenAI(api_key=DASHSCOPE_API_KEY, base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"))
 
 resp = client.chat.completions.create(
     model="deepseek-v4-flash",

--- a/src/perception/smart_pipeline.py
+++ b/src/perception/smart_pipeline.py
@@ -158,7 +158,7 @@ class _QwenAPIClient:
             raise RuntimeError("openai package required: pip install openai")
         self._client = OpenAI(
             api_key=self.api_key,
-            base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"),
+            base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         )
 
     def recognize(self, image_path: str) -> dict:


### PR DESCRIPTION
将 scripts 和 smart_pipeline 中 DASHSCOPE_BASE_URL 的默认地址从 token-plan.cn-beijing.maas.aliyuncs.com 统一为 dashscope.aliyuncs.com。不影响已通过环境变量显式设置的场景。