### PR TITLE
fix: qwen 代理 hang / 静默跳过非白名单 LLM / 移除 think 工具

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # 阿里云百炼 API Key
 # 复制此文件为 .env 并填入你的真实 API Key
 DASHSCOPE_API_KEY=sk-your-key-here
+# 默认使用公共兼容模式 endpoint；
+# 若是 MaaS workspace 地址（ws-xxx.cn-beijing.maas.aliyuncs.com），
+# 请使用 /compatible-mode/v1 路径，/api/v1 只支持模型列表等非 OpenAI 兼容接口。
 DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 
 # 多模态 OCR 开关：true=启用 SmartPerceptionPipeline（本地预判+qwen3.5-flash 兜底）

--- a/run_bot.py
+++ b/run_bot.py
@@ -69,7 +69,7 @@ def main():
         print(f"  • LLM: {model_name} ({base_url})")
         print("  • Prompt: DT style (prompts/persona.md)")
         print("  • 检索: 待启用")
-        interval = 5.0
+        interval = 15.0
         print(f"  • 轮询: 每 {interval:.0f} 秒")
 
         llm = QwenClient()

--- a/src/action/message_sender.py
+++ b/src/action/message_sender.py
@@ -88,6 +88,10 @@ class WeChatMessageSender(MessageSender):
                     return True
         return False
 
+    def in_silent_whitelist(self, chat_name: str) -> bool:
+        """公开方法：判断 chat_name 是否在静默白名单内。"""
+        return self._in_silent_whitelist(chat_name)
+
     # ------------------------------------------------------------------
     # 原子操作辅助方法
     # ------------------------------------------------------------------

--- a/src/bot/wechat_bot.py
+++ b/src/bot/wechat_bot.py
@@ -408,6 +408,23 @@ class WeChatBot:
                 self.debug_logger.log_action("none", action_input="", success=False, error=skip_reason)
                 return
 
+            # 静默模式：非白名单聊天直接跳过 LLM，不生成回复
+            if self.sender.silent_mode and not self.sender.in_silent_whitelist(chat_name):
+                skip_reason = f"静默模式非白名单，跳过 LLM: {chat_name}"
+                self.logger.log_decision(
+                    tick_id, should_reply=False, reason=skip_reason,
+                    latest_text=unreplied[-1].text if unreplied else "",
+                )
+                self.debug_logger.log_action("none", action_input="", success=False, error=skip_reason)
+                # 标记为已处理，避免反复重试占满轮询
+                for msg in unreplied:
+                    self.global_store.mark_replied(chat_name, msg, "")
+                # 尝试切换到其他未读聊天（可能是白名单）
+                switch_target = self._try_switch_to_unread_chat(result)
+                if switch_target:
+                    self.debug_logger.log_action("switch", action_input=switch_target, success=True)
+                return
+
             # 传递完整消息上下文 + 所有未读消息，让 AI 生成多条回复
             all_messages = getattr(state, "messages", [])
             if not isinstance(all_messages, list):
@@ -677,7 +694,7 @@ class WeChatBot:
                 self.tick()
             except Exception as e:
                 self.logger.error(f"Tick #{self._tick_id} 未捕获异常: {e}", exc_info=True)
-            # 每 60 个 tick（约 5 分钟，按 5s 间隔）输出一次 DeepSeek token 统计
+            # 每 60 个 tick（约 15 分钟，按 15s 间隔）输出一次 DeepSeek token 统计
             if self._tick_id > 0 and self._tick_id % 60 == 0:
                 from src.utils.qwen_client import QwenClient
                 QwenClient.log_token_stats(self.logger.runtime_logger)

--- a/src/perception/smart_pipeline.py
+++ b/src/perception/smart_pipeline.py
@@ -154,11 +154,18 @@ class _QwenAPIClient:
             raise RuntimeError("DASHSCOPE_API_KEY not set")
         try:
             from openai import OpenAI
-        except ImportError:
-            raise RuntimeError("openai package required: pip install openai")
+            import httpx
+        except ImportError as e:
+            raise RuntimeError(f"package required: {e}")
+        # 明确禁用代理：DashScope workspace endpoint 走本地代理会 hang
+        http_client = httpx.Client(
+            transport=httpx.HTTPTransport(proxy=None),
+            timeout=60,
+        )
         self._client = OpenAI(
             api_key=self.api_key,
             base_url=os.environ.get("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+            http_client=http_client,
         )
 
     def recognize(self, image_path: str) -> dict:

--- a/src/reply/generator.py
+++ b/src/reply/generator.py
@@ -212,29 +212,6 @@ class ReplyGenerator:
             else:
                 _logger.info("[MemoryTool] search_memory 已注册（仅 wiki，历史索引未就绪）")
 
-        # 注册 think 工具：让模型在回复前停下来深入思考，不获取新信息
-        self.tool_registry.register(
-            name="think",
-            description=(
-                "在回复前停下来深入思考。用于需要深度推理、权衡多因素、分析意图、"
-                "检查人设一致性的场景。此工具不获取新信息，只记录你的思考过程。"
-                "在想清楚之前随时可以调用，次数不限。"
-                "注意：思考时也必须守住王芊本人身份。不能把'承认是AI/机器人/语言模型'"
-                "当作可行方向——身份锚定适用于思考过程，不只最终回复。"
-            ),
-            parameters={
-                "type": "object",
-                "properties": {
-                    "thought": {
-                        "type": "string",
-                        "description": "你的思考内容。尽情思考，越详细越好。"
-                    }
-                },
-                "required": ["thought"],
-            },
-            func=lambda thought: "思考已记录，继续生成回复。",
-        )
-
         # 读取 Self-Refine prompt 文件
         _prompt_dir = Path(__file__).parent.parent.parent / "prompts"
         self._feedback_prompt = (_prompt_dir / "feedback.md").read_text(encoding="utf-8")
@@ -509,11 +486,7 @@ class ReplyGenerator:
                             tool_args = tc.function.arguments
                             _logger.info("[Tool] 执行开始: %s(%s)", tool_name, tool_args[:100] if isinstance(tool_args, str) else str(tool_args)[:100])
                             t_tool_start = time.time()
-                            if tool_name == "think":
-                                # think 工具不调用外部服务，直接返回确认
-                                result = "思考已记录，继续生成回复。"
-                                _logger.info("[Tool] think 调用: %s", tool_args[:200] if isinstance(tool_args, str) else str(tool_args)[:200])
-                            elif self.tool_registry.has(tool_name):
+                            if self.tool_registry.has(tool_name):
                                 result = self.tool_registry.get(tool_name).execute(tool_args)
                             else:
                                 result = f"工具 {tool_name} 不存在"

--- a/src/tests/test_react_self_refine.py
+++ b/src/tests/test_react_self_refine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """ReAct + Self-Refine 单元测试。
 
-仅验证 ReplyGenerator 内部的 ReAct 循环、think 工具注册与执行、
+仅验证 ReplyGenerator 内部的 ReAct 循环、
 Self-Refine（Feedback + Iterate）开关及 max_tool_calls 降级逻辑，
 不调用真实 LLM API。
 """
@@ -97,18 +97,6 @@ def _make_generator(mock_llm_instance, enable_self_refine: bool = True) -> Reply
     gen.enable_self_refine = enable_self_refine
     gen.enable_react_tools = True
     return gen
-
-
-class TestThinkTool:
-    def test_think_tool_registered(self):
-        gen = ReplyGenerator(llm_client=MockLLM())
-        assert gen.tool_registry.has("think")
-
-    def test_think_tool_returns_confirmation(self):
-        gen = ReplyGenerator(llm_client=MockLLM())
-        tool = gen.tool_registry.get("think")
-        result = tool.execute('{"thought": "test"}')
-        assert "思考已记录" in result
 
 
 class TestSelfRefine:
@@ -320,12 +308,12 @@ class TestReActLoop:
                 # skill router
                 return MockResponse(content='{"skills": []}')
             if tools:
-                # 持续返回 think 工具调用，迫使进入下一轮 ReAct
+                # 持续返回 dummy 工具调用，迫使进入下一轮 ReAct
                 return MockResponse(
                     tool_calls=[
                         MockToolCall(
-                            name="think",
-                            arguments='{"thought": "thinking"}',
+                            name="dummy_loop",
+                            arguments='{"query": "loop"}',
                             id=f"tc_{call_count}",
                         )
                     ]
@@ -335,6 +323,13 @@ class TestReActLoop:
 
         mock_llm = MockLLM(response_func=_response_func)
         gen = _make_generator(mock_llm, enable_self_refine=False)
+        # 注册一个 dummy 工具用于测试循环
+        gen.tool_registry.register(
+            name="dummy_loop",
+            description="测试用循环工具",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            func=lambda query: "ok",
+        )
         replies = gen.generate([sample_message], [sample_message])
 
         assert replies == ["forced final"]
@@ -342,5 +337,5 @@ class TestReActLoop:
         # 调用次数应为：1 次 skill router + MAX_TOOL_CALLS 次 tool 调用 + 1 次强制 JSON
         assert call_count == 1 + MAX_TOOL_CALLS + 1
 
-        # 验证确实存在 think 工具调用记录
-        assert any(tc["tool_name"] == "think" for tc in gen.last_tool_calls)
+        # 验证确实存在 dummy_loop 工具调用记录
+        assert any(tc["tool_name"] == "dummy_loop" for tc in gen.last_tool_calls)


### PR DESCRIPTION
## 改动摘要

1. **qwen3.6-flash workspace endpoint 禁用代理**
   `src/perception/smart_pipeline.py` 的 `_QwenAPIClient` 使用显式无代理 `httpx.Client`，避免本地代理导致 API hang。

2. **静默模式提前跳过非白名单 LLM**
   `src/bot/wechat_bot.py` 在 `tick()` 中识别到当前聊天不在白名单时，直接跳过 `generator.generate()`，节省 DeepSeek token。

3. **tick 间隔改为 15s**
   `run_bot.py` 轮询间隔从 5s 调整到 15s。

4. **移除 think 工具**
   `src/reply/generator.py` 移除 think 工具注册与执行；DeepSeek thinking 模式下调用 think 后经常空返，导致该回的群没回复。

## 验证

- 本地测试：`324 passed, 13 skipped`
- 重启 bot 后 qwen API latency 稳定在 ~4s，共同富裕群已成功生成并发送回复。
