### PR TITLE
Add stale bot for automatic issue/PR management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+        stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 60
+        days-before-close: 14
+        exempt-issue-labels: 'pinned,security,good first issue'
+        exempt-pr-labels: 'pinned,security'
+        operations-per-run: 30


### PR DESCRIPTION
## Description\n\nAdds a GitHub Actions workflow that automatically marks issues and PRs as stale after 60 days of inactivity, and closes them after 14 more days without activity.\n\nThis shows active maintenance and keeps the issue tracker clean.\n\n### Configuration\n- Issues stale after 60 days\n- Issues closed after 14 more days\n- Good first issues and security issues are exempt\n- Runs daily at 1:30 AM UTC