### PR TITLE
docs: finish privacy configuration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 
 - **环境**：macOS 12+，Python 3.10+，微信 Mac 版
 - **依赖**：`pip install -r requirements.txt`
-- **配置**：复制 `.env.example` 为 `.env`，填入 API Key
+- **配置**：复制 `.env.example` 为 `.env`，填入 API Key；复制 `prompts/persona.md.example` 为 `data/persona.md`，填写本地人设
+- **隐私**：`.env` 与 `data/` 默认不进入 Git；不要把 API Key、聊天记录或真实人设提交到仓库
 - **权限**：Bot 依赖 macOS 辅助功能/屏幕录制权限，详见下文[权限说明](#权限说明)
 - **启动**：`python3 run_bot.py`
 - **管理后台（LaunchAgent 常驻）**：

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,7 +93,8 @@ Calibrate an LLM-as-Judge with a small amount of human annotation. Once the Judg
 
 - **Environment**: macOS 12+, Python 3.10+, WeChat Mac
 - **Install**: `pip install -r requirements.txt`
-- **Config**: Copy `.env.example` to `.env`, fill in API keys
+- **Config**: Copy `.env.example` to `.env` and fill in API keys; copy `prompts/persona.md.example` to `data/persona.md` and customize the local persona
+- **Privacy**: `.env` and `data/` are excluded from Git by default; never commit API keys, chat history, or a real persona
 - **Permissions**: Enable Screen Recording and Accessibility for your terminal (System Settings → Privacy & Security)
 - **Run**: `python3 run_bot.py`
 - **Test**: Install development dependencies with `pip install -r requirements-dev.txt`, then run `python3 -m pytest src/tests -v`

--- a/docs/01-quickstart/AI_QUICKSTART.md
+++ b/docs/01-quickstart/AI_QUICKSTART.md
@@ -49,7 +49,7 @@ jq . ~/wechat-mac-rpa/data/history/测试群.jsonl
 
 ```bash
 cd /path/to/wechat-mac-rpa
-python -m pytest tests/ -v
+python -m pytest src/tests -v
 ```
 
 ---

--- a/docs/03-guides/PROJECT_STATUS.md
+++ b/docs/03-guides/PROJECT_STATUS.md
@@ -5,6 +5,11 @@
 
 > 本文主体是 2026-05 的历史状态记录，不应作为当前 benchmark 数值来源。当前口径以 README 的“Benchmark 快照”和私有自动报告为准。
 
+## 隐私清理状态（2026-08-15）
+
+- ✅ 仓库内容与当前 Git 历史已匿名化；私人配置统一保存在 Git 忽略的 `data/` 和 `.env` 中。
+- ⏳ **唯一未完成项**：等待 GitHub Support 清理平台管理的缓存、悬空对象和 `refs/pull/*` 残留；处理完成前不得宣称隐私清理全部完成。
+
 ## 当前状态
 - ✅ 项目架构：双感知管道（SmartPerceptionPipeline 主力 + VisionPipeline 备用）
 - ✅ 微信运行（版本 4.1.8）
@@ -27,7 +32,7 @@
 - ⏳ Memory Search alias_wangzong("示例别名辛")召回失败
 - ⏳ 昵称识别准确率仍需优化
 - ⏳ 多显示器场景支持
-- ⏳ GitHub 推送（网络超时，待手动 push）
+- ✅ GitHub 推送已完成（当前 `main` 与 `origin/main` 同步）
 
 ## 最近修复
 

--- a/docs/05-meta/EXPERIMENTS.md
+++ b/docs/05-meta/EXPERIMENTS.md
@@ -24,7 +24,7 @@
 ### 验证方法
 - [ ] 跑 `python3 scripts/doc_lint.py && python3 scripts/doc_review.py`
 - [ ] 跑 `python3 tests/test_integration.py`
-- [ ] 跑 `python3 -m pytest tests/ src/tests/ -v`
+- [ ] 跑 `python3 -m pytest src/tests/ -v`
 - [ ] 手动截图验证 [N] 轮
 - [ ] 其他: [说明]
 


### PR DESCRIPTION
## Summary
- document the local Persona setup and Git privacy boundary in both READMEs
- fix stale test commands and repository push status
- keep GitHub-managed privacy residue explicitly marked as the sole unfinished privacy-cleanup item

## Validation
- `.venv/bin/python scripts/doc_lint.py`
- `.venv/bin/python scripts/check_privacy.py`
- `git diff --check`

No private values are included in this change.